### PR TITLE
Remove explicitly defined copy operator for style::internal::Font

### DIFF
--- a/ui/style/style_core_font.h
+++ b/ui/style/style_core_font.h
@@ -28,11 +28,6 @@ public:
 	Font(int size, uint32 flags, const QString &family);
 	Font(int size, uint32 flags, int family);
 
-	Font &operator=(const Font &other) {
-		ptr = other.ptr;
-		return (*this);
-	}
-
 	FontData *operator->() const {
 		return ptr;
 	}


### PR DESCRIPTION
It was equivalent of default copy operator generated by compiler itself.
Removing this copy operation, we do not change behavior of the code but
resolve the -Wdeprecated-copy warning from GCC.