### PR TITLE
Use DemiBold when using packaged fonts

### DIFF
--- a/ui/style/style_core_font.cpp
+++ b/ui/style/style_core_font.cpp
@@ -234,8 +234,10 @@ FontData::FontData(int size, uint32 flags, int family, Font *other)
 	f.setPixelSize(size);
 	if (_flags & FontBold) {
 		f.setBold(true);
-	//} else if (fontFamilies[family] == "Open Sans Semibold") {
-	//	f.setWeight(QFont::DemiBold);
+#ifdef DESKTOP_APP_USE_PACKAGED_FONTS
+	} else if (fontFamilies[family] == "Open Sans Semibold") {
+		f.setWeight(QFont::DemiBold);
+#endif
 	}
 	f.setItalic(_flags & FontItalic);
 	f.setUnderline(_flags & FontUnderline);


### PR DESCRIPTION
To provide proper text weight when open sans is a optional dependency