### PR TITLE
do not treat non-breaking spaces (U+00A0, dec 160) as normal spaces

### DIFF
--- a/ui/text/text.cpp
+++ b/ui/text/text.cpp
@@ -3408,7 +3408,7 @@ bool IsNewline(QChar ch) {
 }
 
 bool IsSpace(QChar ch, bool rich) {
-	return ch.isSpace()
+	return ( ch.isSpace() && ch != QChar(160) )
 		|| (ch < 32 && !(rich && ch == TextCommand))
 		|| (ch == QChar::ParagraphSeparator)
 		|| (ch == QChar::LineSeparator)


### PR DESCRIPTION
This should be an easy (i.e. one-liner) fix for telegramdesktop/tdesktop#6393 unless it would create some undesired side effect [in `bool CutPart(TextWithEntities &sending, TextWithEntities &left, int32 limit)`](https://github.com/desktop-app/lib_ui/blob/d71d2121b1ffc10d2c5565d911bfa31a505d343a/ui/text/text_entity.cpp#L1467) and thus would become not so easy.