### PR TITLE
do not treat non-breaking spaces (U+00A0, dec 160) as normal spaces

### DIFF
--- a/ui/text/text.cpp
+++ b/ui/text/text.cpp
@@ -743,7 +743,7 @@ void Parser::parseCurrentChar() {
 	_ch = ((_ptr < _end) ? *_ptr : 0);
 	_emojiLookback = 0;
 	const auto isNewLine = _multiline && IsNewline(_ch);
-	const auto isSpace = IsSpace(_ch);
+	const auto isSpace = IsSpace(_ch) && _ch != QChar(160);
 	const auto isDiac = IsDiac(_ch);
 	const auto isTilde = _checkTilde && (_ch == '~');
 	const auto skip = [&] {


### PR DESCRIPTION
This one-liner is intended to become an easy fix for telegramdesktop/tdesktop#6393 and/or telegramdesktop/tdesktop#6477.