### PR TITLE
Call QInputMethod::show on TouchEnd

### DIFF
--- a/ui/widgets/input_fields.cpp
+++ b/ui/widgets/input_fields.cpp
@@ -1045,6 +1045,8 @@ void FlatInput::touchEvent(QTouchEvent *e) {
 			if (_touchRightButton) {
 				QContextMenuEvent contextEvent(QContextMenuEvent::Mouse, mapped, _touchStart);
 				contextMenuEvent(&contextEvent);
+			} else {
+				QGuiApplication::inputMethod()->show();
 			}
 		}
 		if (weak) {
@@ -1654,6 +1656,8 @@ void InputField::handleTouchEvent(QTouchEvent *e) {
 			if (_touchRightButton) {
 				QContextMenuEvent contextEvent(QContextMenuEvent::Mouse, mapped, _touchStart);
 				contextMenuEvent(&contextEvent);
+			} else {
+				QGuiApplication::inputMethod()->show();
 			}
 		}
 		if (weak) {
@@ -3855,6 +3859,8 @@ void MaskedInputField::touchEvent(QTouchEvent *e) {
 			if (_touchRightButton) {
 				QContextMenuEvent contextEvent(QContextMenuEvent::Mouse, mapped, _touchStart);
 				contextMenuEvent(&contextEvent);
+			} else {
+				QGuiApplication::inputMethod()->show();
 			}
 		}
 		if (weak) {


### PR DESCRIPTION
Qt calls QInputMethod::show on mouseReleaseEvent, but tdesktop sets Qt::WA_AcceptTouchEvents, so Qt's callback is never called and the keyboard is never shown. Adding the same to TouchEnd event should synchornize the behavior.

QInputMethod::hide is called in QWidget::focusOutEvent and shouldn't be affected.