### PR TITLE
Fix global scale reset with custom platformthemes

### DIFF
--- a/ui/ui_utility.cpp
+++ b/ui/ui_utility.cpp
@@ -13,6 +13,8 @@
 #include <QtGui/QWindow>
 #include <QtGui/QtEvents>
 #include <QWheelEvent>
+
+#include <private/qguiapplication_p.h>
 #include <private/qhighdpiscaling_p.h>
 
 #include <array>
@@ -214,6 +216,7 @@ bool IsContentVisible(
 
 void DisableCustomScaling() {
 	QHighDpiScaling::setGlobalFactor(1);
+	QGuiApplicationPrivate::resetCachedDevicePixelRatio();
 }
 
 int WheelDirection(not_null<QWheelEvent*> e) {


### PR DESCRIPTION
At least Kvantum makes QGuiApplication constructor to call QGuiApplication::devicePixelRatio, so the value is cached and won't change.

Resetting the cache fixes the issue.