### PR TITLE
Add missing include file to fix compile error

### DIFF
--- a/ui/image/image_prepare.cpp
+++ b/ui/image/image_prepare.cpp
@@ -24,6 +24,8 @@
 
 #include <jpeglib.h>
 
+#include <setjmp.h>
+
 struct my_error_mgr : public jpeg_error_mgr {
 	jmp_buf setjmp_buffer;
 };


### PR DESCRIPTION
Or else compiling with tdesktop:centos_env complains:

```
/usr/src/tdesktop/Telegram/lib_ui/ui/image/image_prepare.cpp:28:2: error: 'jmp_buf' does not name a type
   28 |  jmp_buf setjmp_buffer;
      |  ^~~~~~~
/usr/src/tdesktop/Telegram/lib_ui/ui/image/image_prepare.cpp: In function 'void my_error_exit(j_common_ptr)':
/usr/src/tdesktop/Telegram/lib_ui/ui/image/image_prepare.cpp:35:17: error: 'struct my_error_mgr' has no member named 'setjmp_buffer'
   35 |  longjmp(myerr->setjmp_buffer, 1);
      |                 ^~~~~~~~~~~~~
/usr/src/tdesktop/Telegram/lib_ui/ui/image/image_prepare.cpp:35:2: error: 'longjmp' was not declared in this scope; did you mean 'log1p'?
   35 |  longjmp(myerr->setjmp_buffer, 1);
      |  ^~~~~~~
      |  log1p
/usr/src/tdesktop/Telegram/lib_ui/ui/image/image_prepare.cpp: In function 'bool Images::IsProgressiveJpeg(const QByteArray&)':
/usr/src/tdesktop/Telegram/lib_ui/ui/image/image_prepare.cpp:1243:18: error: 'struct my_error_mgr' has no member named 'setjmp_buffer'
 1243 |  if (setjmp(jerr.setjmp_buffer)) {
      |                  ^~~~~~~~~~~~~
/usr/src/tdesktop/Telegram/lib_ui/ui/image/image_prepare.cpp:1243:6: error: 'setjmp' was not declared in this scope
 1243 |  if (setjmp(jerr.setjmp_buffer)) {
      |      ^~~~~~
```