### PR TITLE
Avoid conditional branching on uninitialized values

### DIFF
--- a/ui/layers/box_layer_widget.h
+++ b/ui/layers/box_layer_widget.h
@@ -128,6 +128,7 @@ private:
 
 	const style::Box *_st = nullptr;
 	not_null<LayerStackWidget*> _layer;
+	bool _layerType = false;
 	int _fullHeight = 0;
 
 	bool _noContentMargin = false;
@@ -140,7 +141,6 @@ private:
 	rpl::variable<QString> _additionalTitle;
 	int _titleLeft = 0;
 	int _titleTop = 0;
-	bool _layerType = false;
 	bool _closeByOutsideClick = true;
 
 	std::vector<object_ptr<RoundButton>> _buttons;

--- a/ui/widgets/checkbox.h
+++ b/ui/widgets/checkbox.h
@@ -228,8 +228,8 @@ private:
 	rpl::event_stream<bool> _checkedChanges;
 	QPixmap _checkCache;
 
-	Text::String _text;
 	style::align _checkAlignment = style::al_left;
+	Text::String _text;
 	int _allowTextLines = 1;
 	bool _textBreakEverywhere = false;
 


### PR DESCRIPTION
C++ initializes members in the order in which they are defined in class. So the order is important if the members are accessed by other initializers or methods called from them.

Class BoxLayerWidget:
 * _roundRect is initialized based on _layerType through the st() method.

```
==121545== Conditional jump or move depends on uninitialised value(s)
==121545==    at 0x6BE7EF6: Ui::BoxLayerWidget::st() const (box_layer_widget.cpp:75)
==121545==    by 0x6BE7960: Ui::BoxLayerWidget::BoxLayerWidget(gsl::not_null<Ui::LayerStackWidget*>, object_ptr<Ui::BoxContent>) (box_layer_widget.cpp:45)
...
```

Class Checkbox:
 * Arguments of _text constructor depend on _checkAlignment through the countTextMinWidth and the checkRect methods.

```
==121545== Conditional jump or move depends on uninitialised value(s)
==121545==    at 0x6A4443D: Ui::Checkbox::checkRect() const (checkbox.cpp:505)
==121545==    by 0x6A44340: Ui::Checkbox::countTextMinWidth() const (checkbox.cpp:496)
==121545==    by 0x6A440FA: Ui::Checkbox::Checkbox(QWidget*, rpl::producer<TextWithEntities, rpl::no_error, rpl::details::type_erased_generator<TextWithEntities, rpl::no_error> >&&, style::Checkbox const&, std::unique_ptr<Ui::AbstractCheckView, std::default_delete<Ui::AbstractCheckView> >) (checkbox.cpp:470)
==121545==    by 0x6A43B91: Ui::Checkbox::Checkbox(QWidget*, rpl::producer<QString, rpl::no_error, rpl::details::type_erased_generator<QString, rpl::no_error> >&&, bool, style::Checkbox const&, style::Check const&) (checkbox.cpp:432)
...
```