### PR TITLE
Add Cascadia Code as preferred monospace font

### DIFF
--- a/ui/basic_click_handlers.cpp
+++ b/ui/basic_click_handlers.cpp
@@ -12,18 +12,18 @@
 #include "base/qthelp_url.h"
 #include "base/qt/qt_string_view.h"
 
-#if defined Q_OS_UNIX && !defined Q_OS_MAC && !defined DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 #include "base/platform/linux/base_linux_app_launch_context.h"
-#endif // Q_OS_UNIX && !Q_OS_MAC && !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 
 #include <QtCore/QUrl>
 #include <QtCore/QRegularExpression>
 #include <QtGui/QDesktopServices>
 #include <QtGui/QGuiApplication>
 
-#if defined Q_OS_UNIX && !defined Q_OS_MAC && !defined DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 #include <giomm.h>
-#endif // Q_OS_UNIX && !Q_OS_MAC && !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 
 QString TextClickHandler::readable() const {
 	const auto result = url();
@@ -88,7 +88,7 @@ void UrlClickHandler::Open(QString url, QVariant context) {
 		if (IsEmail(url)) {
 			url = "mailto: " + url;
 		}
-#if defined Q_OS_UNIX && !defined Q_OS_MAC && !defined DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#ifndef DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 		// Desktop entry spec implementation,
 		// prefer it over QDesktopServices::openUrl since it just calls
 		// the xdg-open shell script that is known to be bugged:
@@ -106,7 +106,7 @@ void UrlClickHandler::Open(QString url, QVariant context) {
 			}
 		} catch (...) {
 		}
-#endif // Q_OS_UNIX && !Q_OS_MAC && !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
+#endif // !DESKTOP_APP_DISABLE_DBUS_INTEGRATION
 		QDesktopServices::openUrl(url);
 	}
 }

--- a/ui/delayed_activation.cpp
+++ b/ui/delayed_activation.cpp
@@ -45,6 +45,7 @@ void ActivateWindowDelayed(not_null<QWidget*> widget) {
 	} else if (std::exchange(Window, widget.get())) {
 		return;
 	}
+#ifndef DESKTOP_APP_DISABLE_X11_INTEGRATION
 	const auto focusAncestor = [&] {
 		const auto focusWidget = QApplication::focusWidget();
 		if (!focusWidget || !widget->window()) {
@@ -52,6 +53,7 @@ void ActivateWindowDelayed(not_null<QWidget*> widget) {
 		}
 		return widget->window()->isAncestorOf(focusWidget);
 	}();
+#endif // !DESKTOP_APP_DISABLE_X11_INTEGRATION
 	crl::on_main(Window, [=] {
 		const auto widget = base::take(Window);
 		if (!widget) {

--- a/ui/style/style_core_font.cpp
+++ b/ui/style/style_core_font.cpp
@@ -98,6 +98,7 @@ bool LoadCustomFont(const QString &filePath, const QString &familyName, int flag
 
 [[nodiscard]] QString ManualMonospaceFont() {
 	const auto kTryFirst = std::initializer_list<QString>{
+		"Cascadia Code",
 		"Consolas",
 		"Liberation Mono",
 		"Menlo",
@@ -259,15 +260,15 @@ QString MonospaceFont() {
 		const auto manual = ManualMonospaceFont();
 		const auto system = SystemMonospaceFont();
 
-#if defined Q_OS_WIN || defined Q_OS_MAC
+#ifdef Q_OS_WIN
 		// Prefer our monospace font.
 		const auto useSystem = manual.isEmpty();
-#else // Q_OS_WIN || Q_OS_MAC
+#else // Q_OS_WIN
 		// Prefer system monospace font.
 		const auto metrics = QFontMetrics(QFont(system));
 		const auto useSystem = manual.isEmpty()
 			|| (metrics.horizontalAdvance(QChar('i')) == metrics.horizontalAdvance(QChar('W')));
-#endif // Q_OS_WIN || Q_OS_MAC
+#endif // Q_OS_WIN
 		return useSystem ? system : manual;
 	}();
 


### PR DESCRIPTION
And switch macOS to system monospace font as Cascadia Code is more likely to be installed by the user