### PR TITLE
Get rid of Ui::Integration::timeFormat

### DIFF
--- a/ui/integration.cpp
+++ b/ui/integration.cpp
@@ -47,10 +47,6 @@ bool Integration::screenIsLocked() {
 	return false;
 }
 
-QString Integration::timeFormat() {
-	return u"hh:mm"_q;
-}
-
 std::shared_ptr<ClickHandler> Integration::createLinkHandler(
 		const EntityLinkData &data,
 		const std::any &context) {

--- a/ui/integration.h
+++ b/ui/integration.h
@@ -49,7 +49,6 @@ public:
 	virtual void activationFromTopPanel();
 
 	[[nodiscard]] virtual bool screenIsLocked();
-	[[nodiscard]] virtual QString timeFormat();
 
 	[[nodiscard]] virtual std::shared_ptr<ClickHandler> createLinkHandler(
 		const EntityLinkData &data,


### PR DESCRIPTION
Enum values are used now instead