### PR TITLE
Avoid event loop being throttled by OpenGL

### DIFF
--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -44,6 +44,12 @@ public:
 
 TWidget::TWidget(QWidget *parent)
 : TWidgetHelper<QWidget>(*(new TWidgetPrivate), parent, {}) {
+	[[maybe_unused]] static const auto Once = [] {
+		auto format = QSurfaceFormat::defaultFormat();
+		format.setSwapInterval(0);
+		QSurfaceFormat::setDefaultFormat(format);
+		return true;
+	}();
 }
 
 namespace Ui {


### PR DESCRIPTION
By default, Qt uses swap interval of 1 what causes the (egl|wgl|glx)SwapBuffers call to wait for vblank. Using swap interval of 0 makes the call to return immediately.