### PR TITLE
Remove a no longer needed workaround for QTextEdit on X11

### DIFF
--- a/ui/widgets/fields/input_field.cpp
+++ b/ui/widgets/fields/input_field.cpp
@@ -2941,9 +2941,6 @@ void InputField::keyPressEventInner(QKeyEvent *e) {
 			? (~Qt::ControlModifier)
 			: (enter && shift)
 			? (~Qt::ShiftModifier)
-			// Qt bug workaround https://bugreports.qt.io/browse/QTBUG-49771
-			: (backspace && Platform::IsX11())
-			? (Qt::ControlModifier)
 			: oldModifiers;
 		const auto changeModifiers = (oldModifiers & ~allowedModifiers) != 0;
 		if (changeModifiers) {


### PR DESCRIPTION
It's fixed in Qt 6.2 and seem to be even backported to 5.15

https://github.com/qt/qtbase/commit/4b0b87b5c2173ee70eacfdd7cea08aea8a5164c8