### PR TITLE
Revert "Do only setFixedSize in PopupMenu"

### DIFF
--- a/ui/widgets/popup_menu.cpp
+++ b/ui/widgets/popup_menu.cpp
@@ -376,9 +376,13 @@ void PopupMenu::handleMenuResize() {
 	_scroll->resize(
 		newWidth - _padding.left() - _padding.right(),
 		scrollHeight);
-	setFixedSize(
-		newWidth,
-		_padding.top() + scrollHeight + _padding.bottom());
+	{
+		const auto newSize = QSize(
+			newWidth,
+			_padding.top() + scrollHeight + _padding.bottom());
+		setFixedSize(newSize);
+		resize(newSize);
+	}
 	_inner = rect().marginsRemoved(_padding);
 }
 


### PR DESCRIPTION
This reverts commit a53c0a747ff495e0985bbb1647272c53cb29d501.

PopupMenu calls handleMenuResize early via _menu->resizesFromInner handler what means it won't resize at the time of actual popup when the screen gets set

Fixes https://github.com/telegramdesktop/tdesktop/issues/28553