### PR TITLE
Fix missing enter from event loop

### DIFF
--- a/ui/platform/linux/ui_window_title_linux.cpp
+++ b/ui/platform/linux/ui_window_title_linux.cpp
@@ -38,7 +38,9 @@ TitleControlsLayoutImpl::TitleControlsLayoutImpl()
 		return xSettings->registerCallbackForProperty(
 			"Gtk/DecorationLayout",
 			[=](xcb_connection_t *, const QByteArray &, const QVariant &) {
-				_variable = Get();
+				base::Integration::Instance().enterFromEventLoop([&] {
+					_variable = Get();
+				});
 			});
 	}
 #endif // !DESKTOP_APP_DISABLE_X11_INTEGRATION


### PR DESCRIPTION
XSettings-based title controls layout update could now come without going through QCoreApplication::notify