### PR TITLE
`Ui::Animations::Simple`: ensure `.start()` starts from `from`

### DIFF
--- a/ui/effects/animations.h
+++ b/ui/effects/animations.h
@@ -381,16 +381,19 @@ inline void Simple::change(
 		anim::transition transition) {
 	Expects(_data != nullptr);
 
-	prepare(0. /* ignored */, duration);
+	prepare(_data->value /* keep the old value */, duration);
 	startPrepared(to, duration, transition);
 }
 
 inline void Simple::prepare(float64 from, crl::time duration) {
 	const auto isLong = (duration > kLongAnimationDuration);
-	if (!_data) {
+	if (_data) {
+		_data->value = from;
+		if (!isLong) {
+			_data->tracker.restart();
+		}
+	} else {
 		_data = std::make_unique<Data>(from);
-	} else if (!isLong) {
-		_data->tracker.restart();
 	}
 	if (isLong) {
 		_data->tracker.release();


### PR DESCRIPTION
Unlike the `.change()` method, which configures a running animation to
go to a different state, the `.start()` method should first set the
initial opacity value, then animate.

It is fixed by making sure the private `.prepare()` method always sets
`from`, rather than ignoring it when the animation is already running.

Part of a fix of telegramdesktop/tdesktop#28811.