### PR TITLE
ui/widgets: use std::nullptr_t instead of nullptr_t

### DIFF
--- a/ui/widgets/buttons.cpp
+++ b/ui/widgets/buttons.cpp
@@ -803,7 +803,7 @@ SettingsButton::SettingsButton(
 
 SettingsButton::SettingsButton(
 	QWidget *parent,
-	nullptr_t,
+	std::nullptr_t,
 	const style::SettingsButton &st)
 : RippleButton(parent, st.ripple)
 , _st(st)

--- a/ui/widgets/buttons.h
+++ b/ui/widgets/buttons.h
@@ -12,6 +12,7 @@
 #include "ui/text/text.h"
 #include "styles/style_widgets.h"
 
+#include <cstddef>
 #include <memory>
 
 class Painter;
@@ -276,7 +277,7 @@ public:
 		const Text::MarkedContext &context = {});
 	SettingsButton(
 		QWidget *parent,
-		nullptr_t,
+		std::nullptr_t,
 		const style::SettingsButton &st = st::defaultSettingsButton);
 	~SettingsButton();
 


### PR DESCRIPTION
This fixes build issues on stricter environments (e.g. with musl libc), where `nullptr_t` is not available in the global namespace.

