### PR TITLE
Add accessibility roles and names for Label, Button, and Field widgets

### DIFF
--- a/ui/abstract_button.cpp
+++ b/ui/abstract_button.cpp
@@ -23,6 +23,7 @@ AbstractButton::AbstractButton(QWidget *parent) : RpWidget(parent) {
 	shownValue()
 		| rpl::filter(_1 == false)
 		| rpl::start_with_next([this] { clearState(); }, lifetime());
+	setFocusPolicy(Qt::StrongFocus);
 }
 
 void AbstractButton::leaveEventHook(QEvent *e) {

--- a/ui/abstract_button.cpp
+++ b/ui/abstract_button.cpp
@@ -16,44 +16,64 @@
 
 namespace Ui {
 
-AbstractButton::AbstractButton(QWidget *parent) : RpWidget(parent) {
-	setMouseTracking(true);
+	AbstractButton::AbstractButton(QWidget* parent) : RpWidget(parent) {
+		setMouseTracking(true);
 
-	using namespace rpl::mappers;
-	shownValue()
-		| rpl::filter(_1 == false)
-		| rpl::start_with_next([this] { clearState(); }, lifetime());
-	setFocusPolicy(Qt::StrongFocus);
-}
-
-void AbstractButton::leaveEventHook(QEvent *e) {
-	if (_state & StateFlag::Down) {
-		return;
+		using namespace rpl::mappers;
+		shownValue()
+			| rpl::filter(_1 == false)
+			| rpl::start_with_next([this] { clearState(); }, lifetime());
 	}
 
-	setOver(false, StateChangeSource::ByHover);
-	return RpWidget::leaveEventHook(e);
-}
+	void AbstractButton::leaveEventHook(QEvent* e) {
+		if (_state & StateFlag::Down) {
+			return;
+		}
 
-void AbstractButton::enterEventHook(QEnterEvent *e) {
-	checkIfOver(mapFromGlobal(QCursor::pos()));
-	return RpWidget::enterEventHook(e);
-}
+		setOver(false, StateChangeSource::ByHover);
+		return RpWidget::leaveEventHook(e);
+	}
 
-void AbstractButton::setAcceptBoth(bool acceptBoth) {
-	_acceptBoth = acceptBoth;
-}
+	void AbstractButton::enterEventHook(QEnterEvent* e) {
+		checkIfOver(mapFromGlobal(QCursor::pos()));
+		return RpWidget::enterEventHook(e);
+	}
 
-void AbstractButton::checkIfOver(QPoint localPos) {
-	auto over = rect().marginsRemoved(getMargins()).contains(localPos);
-	setOver(over, StateChangeSource::ByHover);
-}
+	void AbstractButton::setAcceptBoth(bool acceptBoth) {
+		_acceptBoth = acceptBoth;
+	}
 
-void AbstractButton::mousePressEvent(QMouseEvent *e) {
-	checkIfOver(e->pos());
-	if (_state & StateFlag::Over) {
+	void AbstractButton::checkIfOver(QPoint localPos) {
+		auto over = rect().marginsRemoved(getMargins()).contains(localPos);
+		setOver(over, StateChangeSource::ByHover);
+	}
+
+	void AbstractButton::mousePressEvent(QMouseEvent* e) {
+		checkIfOver(e->pos());
+		if (_state & StateFlag::Over) {
+			const auto set = setDown(
+				true,
+				StateChangeSource::ByPress,
+				e->modifiers(),
+				e->button());
+			if (set) {
+				e->accept();
+			}
+		}
+	}
+
+	void AbstractButton::mouseMoveEvent(QMouseEvent* e) {
+		if (rect().marginsRemoved(getMargins()).contains(e->pos())) {
+			setOver(true, StateChangeSource::ByHover);
+		}
+		else {
+			setOver(false, StateChangeSource::ByHover);
+		}
+	}
+
+	void AbstractButton::mouseReleaseEvent(QMouseEvent* e) {
 		const auto set = setDown(
-			true,
+			false,
 			StateChangeSource::ByPress,
 			e->modifiers(),
 			e->button());
@@ -61,119 +81,143 @@ void AbstractButton::mousePressEvent(QMouseEvent *e) {
 			e->accept();
 		}
 	}
-}
 
-void AbstractButton::mouseMoveEvent(QMouseEvent *e) {
-	if (rect().marginsRemoved(getMargins()).contains(e->pos())) {
-		setOver(true, StateChangeSource::ByHover);
-	} else {
-		setOver(false, StateChangeSource::ByHover);
-	}
-}
-
-void AbstractButton::mouseReleaseEvent(QMouseEvent *e) {
-	const auto set = setDown(
-		false,
-		StateChangeSource::ByPress,
-		e->modifiers(),
-		e->button());
-	if (set) {
-		e->accept();
-	}
-}
-
-void AbstractButton::clicked(
+	void AbstractButton::clicked(
 		Qt::KeyboardModifiers modifiers,
 		Qt::MouseButton button) {
-	_modifiers = modifiers;
-	const auto weak = base::make_weak(this);
-	if (button == Qt::LeftButton) {
-		if (const auto callback = _clickedCallback) {
-			callback();
+		_modifiers = modifiers;
+		const auto weak = base::make_weak(this);
+		if (button == Qt::LeftButton) {
+			if (const auto callback = _clickedCallback) {
+				callback();
+			}
+		}
+		if (weak) {
+			_clicks.fire_copy(button);
 		}
 	}
-	if (weak) {
-		_clicks.fire_copy(button);
-	}
-}
 
-void AbstractButton::setPointerCursor(bool enablePointerCursor) {
-	if (_enablePointerCursor != enablePointerCursor) {
-		_enablePointerCursor = enablePointerCursor;
+	void AbstractButton::setPointerCursor(bool enablePointerCursor) {
+		if (_enablePointerCursor != enablePointerCursor) {
+			_enablePointerCursor = enablePointerCursor;
+			updateCursor();
+		}
+	}
+
+	void AbstractButton::setOver(bool over, StateChangeSource source) {
+		if (over == isOver()) {
+			return;
+		}
+		const auto was = _state;
+		if (over) {
+			_state |= StateFlag::Over;
+			Integration::Instance().registerLeaveSubscription(this);
+		}
+		else {
+			_state &= ~State(StateFlag::Over);
+			Integration::Instance().unregisterLeaveSubscription(this);
+		}
+		onStateChanged(was, source);
 		updateCursor();
+		update();
 	}
-}
 
-void AbstractButton::setOver(bool over, StateChangeSource source) {
-	if (over == isOver()) {
-		return;
-	}
-	const auto was = _state;
-	if (over) {
-		_state |= StateFlag::Over;
-		Integration::Instance().registerLeaveSubscription(this);
-	} else {
-		_state &= ~State(StateFlag::Over);
-		Integration::Instance().unregisterLeaveSubscription(this);
-	}
-	onStateChanged(was, source);
-	updateCursor();
-	update();
-}
-
-bool AbstractButton::setDown(
+	bool AbstractButton::setDown(
 		bool down,
 		StateChangeSource source,
 		Qt::KeyboardModifiers modifiers,
 		Qt::MouseButton button) {
-	if (down
-		&& !(_state & StateFlag::Down)
-		&& (_acceptBoth || button == Qt::LeftButton)) {
-		auto was = _state;
-		_state |= StateFlag::Down;
-		onStateChanged(was, source);
-		return true;
-	} else if (!down && (_state & StateFlag::Down)) {
-		const auto was = _state;
-		_state &= ~State(StateFlag::Down);
-
-		const auto weak = base::make_weak(this);
-		onStateChanged(was, source);
-		if (weak) {
-			if (was & StateFlag::Over) {
-				clicked(modifiers, button);
-			} else {
-				setOver(false, source);
-			}
+		if (down
+			&& !(_state & StateFlag::Down)
+			&& (_acceptBoth || button == Qt::LeftButton)) {
+			auto was = _state;
+			_state |= StateFlag::Down;
+			onStateChanged(was, source);
+			return true;
 		}
-		return true;
-	}
-	return false;
-}
+		else if (!down && (_state & StateFlag::Down)) {
+			const auto was = _state;
+			_state &= ~State(StateFlag::Down);
 
-void AbstractButton::updateCursor() {
-	const auto pointerCursor = _enablePointerCursor && isOver();
-	if (_pointerCursor != pointerCursor) {
-		_pointerCursor = pointerCursor;
-		setCursor(_pointerCursor ? style::cur_pointer : style::cur_default);
+			const auto weak = base::make_weak(this);
+			onStateChanged(was, source);
+			if (weak) {
+				if (was & StateFlag::Over) {
+					clicked(modifiers, button);
+				}
+				else {
+					setOver(false, source);
+				}
+			}
+			return true;
+		}
+		return false;
 	}
-}
 
-void AbstractButton::setDisabled(bool disabled) {
-	auto was = _state;
-	if (disabled && !(_state & StateFlag::Disabled)) {
-		_state |= StateFlag::Disabled;
+	void AbstractButton::updateCursor() {
+		const auto pointerCursor = _enablePointerCursor && isOver();
+		if (_pointerCursor != pointerCursor) {
+			_pointerCursor = pointerCursor;
+			setCursor(_pointerCursor ? style::cur_pointer : style::cur_default);
+		}
+	}
+
+	void AbstractButton::setDisabled(bool disabled) {
+		auto was = _state;
+		if (disabled && !(_state & StateFlag::Disabled)) {
+			_state |= StateFlag::Disabled;
+			onStateChanged(was, StateChangeSource::ByUser);
+		}
+		else if (!disabled && (_state & StateFlag::Disabled)) {
+			_state &= ~State(StateFlag::Disabled);
+			onStateChanged(was, StateChangeSource::ByUser);
+		}
+	}
+
+	void AbstractButton::clearState() {
+		auto was = _state;
+		_state = StateFlag::None;
 		onStateChanged(was, StateChangeSource::ByUser);
-	} else if (!disabled && (_state & StateFlag::Disabled)) {
-		_state &= ~State(StateFlag::Disabled);
-		onStateChanged(was, StateChangeSource::ByUser);
 	}
-}
 
-void AbstractButton::clearState() {
-	auto was = _state;
-	_state = StateFlag::None;
-	onStateChanged(was, StateChangeSource::ByUser);
-}
+	void AbstractButton::keyPressEvent(QKeyEvent* e) {
+		// اگر دکمه غیرفعال است یا کلید فشرده شده Space یا Enter نیست، رویداد را به کلاس والد بسپار
+		if (isDisabled() || (e->key() != Qt::Key_Space && e->key() != Qt::Key_Return && e->key() != Qt::Key_Enter)) {
+			RpWidget::keyPressEvent(e);
+			return;
+		}
+
+		// به فشردن ممتد کلید (auto-repeat) واکنشی نشان نده
+		if (e->isAutoRepeat()) {
+			e->accept();
+			return;
+		}
+
+		// یک weak pointer از شیء فعلی می‌سازیم تا بتوانیم زنده بودن آن را بررسی کنیم
+		const auto weak = base::make_weak(this);
+
+		const auto wasOver = isOver();
+		if (!wasOver) {
+			setOver(true, StateChangeSource::ByUser);
+		}
+
+		// چرخه کامل "فشردن" و "رها کردن" را شبیه‌سازی می‌کنیم
+		setDown(true, StateChangeSource::ByPress, e->modifiers(), Qt::LeftButton);
+		setDown(false, StateChangeSource::ByPress, e->modifiers(), Qt::LeftButton);
+
+		// *** بررسی حیاتی ***
+		// بعد از اجرای کلیک، بررسی می‌کنیم که آیا دکمه هنوز وجود دارد یا خیر
+		if (!weak) {
+			e->accept();
+			return; // دکمه حذف شده است، ادامه نده
+		}
+
+		// اگر دکمه هنوز وجود داشت، وضعیت Over را به حالت اولیه باز می‌گردانیم
+		if (!wasOver) {
+			setOver(false, StateChangeSource::ByUser);
+		}
+
+		e->accept();
+	}
 
 } // namespace Ui

--- a/ui/abstract_button.h
+++ b/ui/abstract_button.h
@@ -66,6 +66,7 @@ protected:
 	void mousePressEvent(QMouseEvent *e) override;
 	void mouseMoveEvent(QMouseEvent *e) override;
 	void mouseReleaseEvent(QMouseEvent *e) override;
+	void keyPressEvent(QKeyEvent* e) override;
 
 protected:
 	enum class StateFlag {

--- a/ui/widgets/buttons.cpp
+++ b/ui/widgets/buttons.cpp
@@ -20,1015 +20,1094 @@
 #include <QtGui/QtEvents>
 
 namespace Ui {
-namespace {
+	namespace {
 
-class SimpleRippleButton : public RippleButton {
-public:
-	using RippleButton::RippleButton;
+		class SimpleRippleButton : public RippleButton {
+		public:
+			using RippleButton::RippleButton;
 
-protected:
-	QPoint prepareRippleStartPosition() const override final {
-		const auto result = mapFromGlobal(QCursor::pos());
-		return rect().contains(result)
+		protected:
+			QPoint prepareRippleStartPosition() const override final {
+				const auto result = mapFromGlobal(QCursor::pos());
+				return rect().contains(result)
+					? result
+					: DisabledRippleStartPosition();
+			}
+
+		};
+
+		class SimpleCircleButton final : public SimpleRippleButton {
+		public:
+			using SimpleRippleButton::SimpleRippleButton;
+
+		protected:
+			QImage prepareRippleMask() const override final {
+				return RippleAnimation::EllipseMask(size());
+			}
+
+		};
+
+		class SimpleRoundButton final : public SimpleRippleButton {
+		public:
+			using SimpleRippleButton::SimpleRippleButton;
+
+		protected:
+			QImage prepareRippleMask() const override final {
+				return RippleAnimation::RoundRectMask(size(), st::buttonRadius);
+			}
+
+		};
+
+	} // namespace
+
+	LinkButton::LinkButton(
+		QWidget* parent,
+		const QString& text,
+		const style::LinkButton& st)
+		: AbstractButton(parent)
+		, _st(st)
+		, _text(text)
+		, _textWidth(st.font->width(_text)) {
+		resizeToText();
+		setCursor(style::cur_pointer);
+
+		Accessibility::ObserveScreenReaderState(this, [this](bool isActive) {
+			if (isActive) {
+				setFocusPolicy(Qt::StrongFocus);
+			}
+			else {
+				setFocusPolicy(Qt::NoFocus);
+			}
+			});
+		Accessibility::SetRole(this, QAccessible::Role::Link);
+		setAccessibleName(text);
+	}
+
+	void LinkButton::paintEvent(QPaintEvent* e) {
+		Painter p(this);
+
+		const auto& font = (isOver() ? _st.overFont : _st.font);
+		const auto pen = _textFgOverride.has_value()
+			? QPen(*_textFgOverride)
+			: isOver()
+			? _st.overColor
+			: _st.color;
+		p.setFont(font);
+		p.setPen(pen);
+		const auto left = _st.padding.left();
+		const auto top = _st.padding.top() + font->ascent;
+		if (width() < naturalWidth()) {
+			const auto available = width() - left - _st.padding.right();
+			p.drawText(left, top, font->elided(_text, available));
+		}
+		else {
+			p.drawText(left, top, _text);
+		}
+	}
+
+	void LinkButton::setText(const QString& text) {
+		_text = text;
+		_textWidth = _st.font->width(_text);
+		setAccessibleName(text);
+		resizeToText();
+		update();
+	}
+
+	void LinkButton::resizeToText() {
+		setNaturalWidth(_st.padding.left() + _textWidth + _st.padding.right());
+	}
+
+	int LinkButton::resizeGetHeight(int newWidth) {
+		return _st.padding.top() + _st.font->height + _st.padding.bottom();
+	}
+
+	void LinkButton::setColorOverride(std::optional<QColor> textFg) {
+		_textFgOverride = textFg;
+		update();
+	}
+
+	void LinkButton::onStateChanged(State was, StateChangeSource source) {
+		update();
+	}
+
+	RippleButton::RippleButton(QWidget* parent, const style::RippleAnimation& st)
+		: AbstractButton(parent)
+		, _st(st) {
+	}
+
+	void RippleButton::clearState() {
+		AbstractButton::clearState();
+		finishAnimating();
+	}
+
+	void RippleButton::finishAnimating() {
+		if (_ripple) {
+			_ripple.reset();
+			update();
+		}
+	}
+
+	void RippleButton::setForceRippled(
+		bool rippled,
+		anim::type animated) {
+		if (_forceRippled != rippled) {
+			_forceRippled = rippled;
+			if (_forceRippled) {
+				_forceRippledSubscription = style::PaletteChanged(
+				) | rpl::filter([=] {
+					return _ripple != nullptr;
+					}) | rpl::start_with_next([=] {
+						_ripple->forceRepaint();
+						});
+					ensureRipple();
+					if (_ripple->empty()) {
+						_ripple->addFading();
+					}
+					else {
+						_ripple->lastUnstop();
+					}
+			}
+			else {
+				if (_ripple) {
+					_ripple->lastStop();
+				}
+				_forceRippledSubscription.destroy();
+			}
+		}
+		if (animated == anim::type::instant && _ripple) {
+			_ripple->lastFinish();
+		}
+		update();
+	}
+
+	void RippleButton::paintRipple(
+		QPainter& p,
+		const QPoint& point,
+		const QColor* colorOverride) {
+		paintRipple(p, point.x(), point.y(), colorOverride);
+	}
+
+	void RippleButton::paintRipple(QPainter& p, int x, int y, const QColor* colorOverride) {
+		if (_ripple) {
+			_ripple->paint(p, x, y, width(), colorOverride);
+			if (_ripple->empty()) {
+				_ripple.reset();
+			}
+		}
+	}
+
+	void RippleButton::onStateChanged(State was, StateChangeSource source) {
+		update();
+
+		auto wasDown = static_cast<bool>(was & StateFlag::Down);
+		auto down = isDown();
+		if (!_st.showDuration || down == wasDown || _forceRippled) {
+			return;
+		}
+
+		if (down && (source == StateChangeSource::ByPress)) {
+			// Start a ripple only from mouse press.
+			auto position = prepareRippleStartPosition();
+			if (position != DisabledRippleStartPosition()) {
+				ensureRipple();
+				_ripple->add(position);
+			}
+		}
+		else if (!down && _ripple) {
+			// Finish ripple anyway.
+			_ripple->lastStop();
+		}
+	}
+
+	void RippleButton::ensureRipple() {
+		if (!_ripple) {
+			_ripple = std::make_unique<RippleAnimation>(_st, prepareRippleMask(), [this] { update(); });
+		}
+	}
+
+	QImage RippleButton::prepareRippleMask() const {
+		return RippleAnimation::RectMask(size());
+	}
+
+	QPoint RippleButton::prepareRippleStartPosition() const {
+		return mapFromGlobal(QCursor::pos());
+	}
+
+	RippleButton::~RippleButton() = default;
+
+	FlatButton::FlatButton(
+		QWidget* parent,
+		const QString& text,
+		const style::FlatButton& st)
+		: RippleButton(parent, st.ripple)
+		, _text(text)
+		, _st(st) {
+		if (_st.width < 0) {
+			_width = textWidth() - _st.width;
+		}
+		else if (!_st.width) {
+			_width = textWidth() + _st.height - _st.font->height;
+		}
+		else {
+			_width = _st.width;
+		}
+		resize(_width, _st.height);
+		Accessibility::ObserveScreenReaderState(this, [this](bool isActive) {
+			if (isActive) {
+				setFocusPolicy(Qt::StrongFocus);
+			}
+			else {
+				setFocusPolicy(Qt::NoFocus);
+			}
+			});
+		Accessibility::SetRole(this, QAccessible::Role::PushButton);
+		setAccessibleName(text);
+	}
+
+	void FlatButton::setText(const QString& text) {
+		_text = text;
+		setAccessibleName(text);
+		update();
+	}
+
+	void FlatButton::setWidth(int w) {
+		_width = w;
+		if (_width < 0) {
+			_width = textWidth() - _st.width;
+		}
+		else if (!_width) {
+			_width = textWidth() + _st.height - _st.font->height;
+		}
+		resize(_width, height());
+	}
+
+	void FlatButton::setColorOverride(std::optional<QColor> color) {
+		_colorOverride = color;
+		update();
+	}
+
+	int32 FlatButton::textWidth() const {
+		return _st.font->width(_text);
+	}
+
+	void FlatButton::onStateChanged(State was, StateChangeSource source) {
+		RippleButton::onStateChanged(was, source);
+		update();
+	}
+
+	void FlatButton::paintEvent(QPaintEvent* e) {
+		QPainter p(this);
+
+		const auto inner = QRect(0, height() - _st.height, width(), _st.height);
+		p.fillRect(inner, isOver() ? _st.overBgColor : _st.bgColor);
+
+		paintRipple(p, 0, 0);
+
+		p.setFont(isOver() ? _st.overFont : _st.font);
+		p.setRenderHint(QPainter::TextAntialiasing);
+		if (_colorOverride) {
+			p.setPen(*_colorOverride);
+		}
+		else {
+			p.setPen(isOver() ? _st.overColor : _st.color);
+		}
+
+		const auto textRect = inner.marginsRemoved(
+			_textMargins
+		).marginsRemoved(
+			{ 0, _st.textTop, 0, 0 }
+		);
+		p.drawText(textRect, _text, style::al_top);
+	}
+
+	void FlatButton::setTextMargins(QMargins margins) {
+		_textMargins = margins;
+		update();
+	}
+
+	RoundButton::RoundButton(
+		QWidget* parent,
+		rpl::producer<QString> text,
+		const style::RoundButton& st)
+		: RippleButton(parent, st.ripple)
+		, _textFull(std::move(text) | rpl::map(Text::WithEntities))
+		, _st(st)
+		, _roundRect(st.radius ? st.radius : st::buttonRadius, _st.textBg)
+		, _roundRectOver(st.radius ? st.radius : st::buttonRadius, _st.textBgOver) {
+		Accessibility::ObserveScreenReaderState(this, [this](bool isActive) {
+			if (isActive) {
+				setFocusPolicy(Qt::StrongFocus);
+			}
+			else {
+				setFocusPolicy(Qt::NoFocus);
+			}
+			});
+		Accessibility::SetRole(this, QAccessible::Role::PushButton);
+		_textFull.value(
+		) | rpl::start_with_next([=](const TextWithEntities& text) {
+			resizeToText(text);
+			setAccessibleName(text.text);
+			}, lifetime());
+	}
+
+	void RoundButton::setTextTransform(TextTransform transform) {
+		_transform = transform;
+		resizeToText(_textFull.current());
+	}
+
+	void RoundButton::setText(rpl::producer<QString> text) {
+		_textFull = std::move(text) | rpl::map(Text::WithEntities);
+	}
+
+	void RoundButton::setText(rpl::producer<TextWithEntities> text) {
+		_textFull = std::move(text);
+	}
+
+	void RoundButton::setContext(const Text::MarkedContext& context) {
+		_context = context;
+		resizeToText(_textFull.current());
+	}
+
+	void RoundButton::setNumbersText(const QString& numbersText, int numbers) {
+		if (numbersText.isEmpty()) {
+			_numbers.reset();
+		}
+		else {
+			if (!_numbers) {
+				const auto& font = _st.style.font;
+				_numbers = std::make_unique<NumbersAnimation>(font, [this] {
+					numbersAnimationCallback();
+					});
+			}
+			_numbers->setText(numbersText, numbers);
+		}
+		resizeToText(_textFull.current());
+	}
+
+	void RoundButton::setWidthChangedCallback(Fn<void()> callback) {
+		if (!_numbers) {
+			const auto& font = _st.style.font;
+			_numbers = std::make_unique<NumbersAnimation>(font, [this] {
+				numbersAnimationCallback();
+				});
+		}
+		_numbers->setWidthChangedCallback(std::move(callback));
+	}
+
+	void RoundButton::setBrushOverride(std::optional<QBrush> brush) {
+		_brushOverride = std::move(brush);
+		update();
+	}
+
+	void RoundButton::setPenOverride(std::optional<QPen> pen) {
+		_penOverride = std::move(pen);
+		update();
+	}
+
+	void RoundButton::finishNumbersAnimation() {
+		if (_numbers) {
+			_numbers->finishAnimating();
+		}
+	}
+
+	void RoundButton::numbersAnimationCallback() {
+		resizeToText(_textFull.current());
+	}
+
+	void RoundButton::setFullWidth(int newFullWidth) {
+		_fullWidthOverride = newFullWidth;
+		resizeToText(_textFull.current());
+	}
+
+	void RoundButton::setFullRadius(bool enabled) {
+		_fullRadius = enabled;
+		update();
+	}
+
+	void RoundButton::resizeToText(const TextWithEntities& text) {
+		if (_transform == TextTransform::ToUpper) {
+			_text.setMarkedText(
+				_st.style,
+				{ text.text.toUpper(), text.entities },
+				kMarkupTextOptions,
+				_context);
+		}
+		else {
+			_text.setMarkedText(_st.style, text, kMarkupTextOptions, _context);
+		}
+		int innerWidth = _text.maxWidth() + addedWidth();
+		if (_fullWidthOverride > 0) {
+			const auto padding = _fullRadius
+				? (_st.padding.left() + _st.padding.right())
+				: 0;
+			resize(
+				_fullWidthOverride + padding,
+				_st.height + _st.padding.top() + _st.padding.bottom());
+		}
+		else if (_fullWidthOverride < 0) {
+			resize(
+				innerWidth - _fullWidthOverride,
+				_st.height + _st.padding.top() + _st.padding.bottom());
+		}
+		else if (_st.width <= 0) {
+			resize(
+				innerWidth - _st.width + _st.padding.left() + _st.padding.right(),
+				_st.height + _st.padding.top() + _st.padding.bottom());
+		}
+		else {
+			resize(
+				_st.width + _st.padding.left() + _st.padding.right(),
+				_st.height + _st.padding.top() + _st.padding.bottom());
+		}
+		setNaturalWidth(width());
+
+		update();
+	}
+
+	int RoundButton::addedWidth() const {
+		auto result = 0;
+		if (_numbers) {
+			result += (result ? _st.numbersSkip : 0) + _numbers->countWidth();
+		}
+		if (!_st.icon.empty() && _st.iconPosition.x() < 0) {
+			result += _st.icon.width() - _st.iconPosition.x();
+		}
+		return result;
+	}
+
+	int RoundButton::contentWidth() const {
+		auto result = _text.maxWidth() + addedWidth();
+		if (_fullWidthOverride < 0) {
+			return result;
+		}
+		else if (_fullWidthOverride > 0) {
+			const auto padding = _fullRadius
+				? (_st.padding.left() + _st.padding.right())
+				: 0;
+			const auto delta = _st.height - _st.style.font->height;
+			if (_fullWidthOverride < result + delta) {
+				return std::max(_fullWidthOverride - delta - padding, 1);
+			}
+		}
+		return std::min(
+			result,
+			width() - _st.padding.left() - _st.padding.right());
+	}
+
+	void RoundButton::paintEvent(QPaintEvent* e) {
+		Painter p(this);
+
+		auto innerWidth = contentWidth();
+		auto rounded = rect().marginsRemoved(_st.padding);
+		if (_fullWidthOverride < 0) {
+			rounded = QRect(0, rounded.top(), innerWidth - _fullWidthOverride, rounded.height());
+		}
+		const auto drawRect = [&](const RoundRect& rect) {
+			const auto fill = myrtlrect(rounded);
+			if (_fullRadius) {
+				const auto radius = rounded.height() / 2;
+				PainterHighQualityEnabler hq(p);
+				p.setPen(_penOverride ? *_penOverride : Qt::NoPen);
+				p.setBrush(_brushOverride ? *_brushOverride : rect.color()->b);
+				p.drawRoundedRect(fill, radius, radius);
+			}
+			else if (_brushOverride) {
+				PainterHighQualityEnabler hq(p);
+				p.setPen(_penOverride ? *_penOverride : Qt::NoPen);
+				p.setBrush(*_brushOverride);
+				const auto radius = _st.radius ? _st.radius : st::buttonRadius;
+				p.drawRoundedRect(fill, radius, radius);
+			}
+			else {
+				rect.paint(p, fill);
+			}
+			};
+		if (_penOverride) {
+			paintRipple(p, rounded.topLeft());
+		}
+		drawRect(_roundRect);
+
+		auto over = isOver();
+		auto down = isDown();
+		if (!_brushOverride && (over || down)) {
+			drawRect(_roundRectOver);
+		}
+
+		if (!_penOverride) {
+			paintRipple(p, rounded.topLeft());
+		}
+
+		const auto textTop = _st.padding.top() + _st.textTop;
+		auto textLeft = _st.padding.left()
+			+ ((width()
+				- innerWidth
+				- _st.padding.left()
+				- _st.padding.right()) / 2);
+		if (_fullWidthOverride < 0) {
+			textLeft = -_fullWidthOverride / 2;
+		}
+		if (!_st.icon.empty() && _st.iconPosition.x() < 0) {
+			textLeft += _st.icon.width() - _st.iconPosition.x();
+		}
+		const auto iconLeft = (_st.iconPosition.x() >= 0)
+			? _st.iconPosition.x()
+			: (textLeft + _st.iconPosition.x() - _st.icon.width());
+		const auto iconTop = (_st.iconPosition.y() >= 0)
+			? _st.iconPosition.y()
+			: (textTop + _st.iconPosition.y());
+		const auto widthForText = std::max(innerWidth - addedWidth(), 0);
+		if (!_text.isEmpty()) {
+			p.setPen((over || down) ? _st.textFgOver : _st.textFg);
+			_text.draw(p, {
+				.position = { textLeft, textTop },
+				.availableWidth = widthForText,
+				.elisionLines = 1,
+				});
+		}
+		if (_numbers) {
+			textLeft += widthForText + (widthForText ? _st.numbersSkip : 0);
+			p.setFont(_st.style.font);
+			p.setPen((over || down) ? _st.numbersTextFgOver : _st.numbersTextFg);
+			_numbers->paint(p, textLeft, textTop, width());
+		}
+		if (!_st.icon.empty()) {
+			const auto& current = ((over || down) && !_st.iconOver.empty())
+				? _st.iconOver
+				: _st.icon;
+			current.paint(p, QPoint(iconLeft, iconTop), width());
+		}
+	}
+
+	QImage RoundButton::prepareRippleMask() const {
+		auto innerWidth = contentWidth();
+		auto rounded = style::rtlrect(rect().marginsRemoved(_st.padding), width());
+		if (_fullWidthOverride < 0) {
+			rounded = QRect(0, rounded.top(), innerWidth - _fullWidthOverride, rounded.height());
+		}
+		return RippleAnimation::RoundRectMask(
+			rounded.size(),
+			(_fullRadius
+				? (rounded.height() / 2)
+				: _st.radius
+				? _st.radius
+				: st::buttonRadius));
+	}
+
+	QPoint RoundButton::prepareRippleStartPosition() const {
+		return mapFromGlobal(QCursor::pos()) - QPoint(_st.padding.left(), _st.padding.top());
+	}
+
+	RoundButton::~RoundButton() = default;
+
+	IconButton::IconButton(QWidget* parent, const style::IconButton& st) : RippleButton(parent, st.ripple)
+		, _st(st) {
+		resize(_st.width, _st.height);
+		Accessibility::ObserveScreenReaderState(this, [this](bool isActive) {
+			if (isActive) {
+				setFocusPolicy(Qt::StrongFocus);
+			}
+			else {
+				setFocusPolicy(Qt::NoFocus);
+			}
+			});
+		Accessibility::SetRole(this, QAccessible::Role::PushButton);
+	}
+
+	const style::IconButton& IconButton::st() const {
+		return _st;
+	}
+
+	void IconButton::setIconOverride(const style::icon* iconOverride, const style::icon* iconOverOverride) {
+		_iconOverride = iconOverride;
+		_iconOverrideOver = iconOverOverride;
+		update();
+	}
+
+	void IconButton::setRippleColorOverride(const style::color* colorOverride) {
+		_rippleColorOverride = colorOverride;
+	}
+
+	float64 IconButton::iconOverOpacity() const {
+		return (isDown() || forceRippled())
+			? 1.
+			: _a_over.value(isOver() ? 1. : 0.);
+	}
+
+	void IconButton::paintEvent(QPaintEvent* e) {
+		Painter p(this);
+
+		paintRipple(p, _st.rippleAreaPosition, _rippleColorOverride ? &(*_rippleColorOverride)->c : nullptr);
+
+		const auto overIconOpacity = iconOverOpacity();
+		const auto overIcon = [&] {
+			if (_iconOverrideOver) {
+				return _iconOverrideOver;
+			}
+			else if (!_st.iconOver.empty()) {
+				return &_st.iconOver;
+			}
+			else if (_iconOverride) {
+				return _iconOverride;
+			}
+			return &_st.icon;
+			};
+		const auto justIcon = [&] {
+			if (_iconOverride) {
+				return _iconOverride;
+			}
+			return &_st.icon;
+			};
+		const auto icon = (overIconOpacity == 1.) ? overIcon() : justIcon();
+		auto position = _st.iconPosition;
+		if (position.x() < 0) {
+			position.setX((width() - icon->width()) / 2);
+		}
+		if (position.y() < 0) {
+			position.setY((height() - icon->height()) / 2);
+		}
+		icon->paint(p, position, width());
+		if (overIconOpacity > 0. && overIconOpacity < 1.) {
+			const auto iconOver = overIcon();
+			if (iconOver != icon) {
+				p.setOpacity(overIconOpacity);
+				iconOver->paint(p, position, width());
+			}
+		}
+	}
+
+	void IconButton::onStateChanged(State was, StateChangeSource source) {
+		RippleButton::onStateChanged(was, source);
+
+		auto over = isOver();
+		auto wasOver = static_cast<bool>(was & StateFlag::Over);
+		if (over != wasOver) {
+			if (_st.duration) {
+				auto from = over ? 0. : 1.;
+				auto to = over ? 1. : 0.;
+				_a_over.start([this] { update(); }, from, to, _st.duration);
+			}
+			else {
+				update();
+			}
+		}
+	}
+
+	QPoint IconButton::prepareRippleStartPosition() const {
+		auto result = mapFromGlobal(QCursor::pos())
+			- _st.rippleAreaPosition;
+		auto rect = QRect(0, 0, _st.rippleAreaSize, _st.rippleAreaSize);
+		return rect.contains(result)
 			? result
 			: DisabledRippleStartPosition();
 	}
 
-};
-
-class SimpleCircleButton final : public SimpleRippleButton {
-public:
-	using SimpleRippleButton::SimpleRippleButton;
-
-protected:
-	QImage prepareRippleMask() const override final {
-		return RippleAnimation::EllipseMask(size());
+	QImage IconButton::prepareRippleMask() const {
+		return RippleAnimation::EllipseMask(QSize(_st.rippleAreaSize, _st.rippleAreaSize));
 	}
 
-};
-
-class SimpleRoundButton final : public SimpleRippleButton {
-public:
-	using SimpleRippleButton::SimpleRippleButton;
-
-protected:
-	QImage prepareRippleMask() const override final {
-		return RippleAnimation::RoundRectMask(size(), st::buttonRadius);
-	}
-
-};
-
-} // namespace
-
-LinkButton::LinkButton(
-	QWidget *parent,
-	const QString &text,
-	const style::LinkButton &st)
-: AbstractButton(parent)
-, _st(st)
-, _text(text)
-, _textWidth(st.font->width(_text)) {
-	resizeToText();
-	setCursor(style::cur_pointer);
-	Accessibility::SetRole(this, QAccessible::Role::Link);
-	setAccessibleName(text);
-}
-
-void LinkButton::paintEvent(QPaintEvent *e) {
-	Painter p(this);
-
-	const auto &font = (isOver() ? _st.overFont : _st.font);
-	const auto pen = _textFgOverride.has_value()
-		? QPen(*_textFgOverride)
-		: isOver()
-		? _st.overColor
-		: _st.color;
-	p.setFont(font);
-	p.setPen(pen);
-	const auto left = _st.padding.left();
-	const auto top = _st.padding.top() + font->ascent;
-	if (width() < naturalWidth()) {
-		const auto available = width() - left - _st.padding.right();
-		p.drawText(left, top, font->elided(_text, available));
-	} else {
-		p.drawText(left, top, _text);
-	}
-}
-
-void LinkButton::setText(const QString &text) {
-	_text = text;
-	_textWidth = _st.font->width(_text);
-	setAccessibleName(text);
-	resizeToText();
-	update();
-}
-
-void LinkButton::resizeToText() {
-	setNaturalWidth(_st.padding.left() + _textWidth + _st.padding.right());
-}
-
-int LinkButton::resizeGetHeight(int newWidth) {
-	return _st.padding.top() + _st.font->height + _st.padding.bottom();
-}
-
-void LinkButton::setColorOverride(std::optional<QColor> textFg) {
-	_textFgOverride = textFg;
-	update();
-}
-
-void LinkButton::onStateChanged(State was, StateChangeSource source) {
-	update();
-}
-
-RippleButton::RippleButton(QWidget *parent, const style::RippleAnimation &st)
-: AbstractButton(parent)
-, _st(st) {
-}
-
-void RippleButton::clearState() {
-	AbstractButton::clearState();
-	finishAnimating();
-}
-
-void RippleButton::finishAnimating() {
-	if (_ripple) {
-		_ripple.reset();
-		update();
-	}
-}
-
-void RippleButton::setForceRippled(
-		bool rippled,
-		anim::type animated) {
-	if (_forceRippled != rippled) {
-		_forceRippled = rippled;
-		if (_forceRippled) {
-			_forceRippledSubscription = style::PaletteChanged(
-			) | rpl::filter([=] {
-				return _ripple != nullptr;
-			}) | rpl::start_with_next([=] {
-				_ripple->forceRepaint();
-			});
-			ensureRipple();
-			if (_ripple->empty()) {
-				_ripple->addFading();
-			} else {
-				_ripple->lastUnstop();
+	CrossButton::CrossButton(QWidget* parent, const style::CrossButton& st) : RippleButton(parent, st.ripple)
+		, _st(st)
+		, _loadingAnimation([=](crl::time now) { return loadingCallback(now); }) {
+		resize(_st.width, _st.height);
+		setCursor(style::cur_pointer);
+		setVisible(false);
+		Accessibility::ObserveScreenReaderState(this, [this](bool isActive) {
+			if (isActive) {
+				setFocusPolicy(Qt::StrongFocus);
 			}
-		} else {
-			if (_ripple) {
-				_ripple->lastStop();
+			else {
+				setFocusPolicy(Qt::NoFocus);
 			}
-			_forceRippledSubscription.destroy();
-		}
-	}
-	if (animated == anim::type::instant && _ripple) {
-		_ripple->lastFinish();
-	}
-	update();
-}
-
-void RippleButton::paintRipple(
-		QPainter &p,
-		const QPoint &point,
-		const QColor *colorOverride) {
-	paintRipple(p, point.x(), point.y(), colorOverride);
-}
-
-void RippleButton::paintRipple(QPainter &p, int x, int y, const QColor *colorOverride) {
-	if (_ripple) {
-		_ripple->paint(p, x, y, width(), colorOverride);
-		if (_ripple->empty()) {
-			_ripple.reset();
-		}
-	}
-}
-
-void RippleButton::onStateChanged(State was, StateChangeSource source) {
-	update();
-
-	auto wasDown = static_cast<bool>(was & StateFlag::Down);
-	auto down = isDown();
-	if (!_st.showDuration || down == wasDown || _forceRippled) {
-		return;
-	}
-
-	if (down && (source == StateChangeSource::ByPress)) {
-		// Start a ripple only from mouse press.
-		auto position = prepareRippleStartPosition();
-		if (position != DisabledRippleStartPosition()) {
-			ensureRipple();
-			_ripple->add(position);
-		}
-	} else if (!down && _ripple) {
-		// Finish ripple anyway.
-		_ripple->lastStop();
-	}
-}
-
-void RippleButton::ensureRipple() {
-	if (!_ripple) {
-		_ripple = std::make_unique<RippleAnimation>(_st, prepareRippleMask(), [this] { update(); });
-	}
-}
-
-QImage RippleButton::prepareRippleMask() const {
-	return RippleAnimation::RectMask(size());
-}
-
-QPoint RippleButton::prepareRippleStartPosition() const {
-	return mapFromGlobal(QCursor::pos());
-}
-
-RippleButton::~RippleButton() = default;
-
-FlatButton::FlatButton(
-	QWidget *parent,
-	const QString &text,
-	const style::FlatButton &st)
-: RippleButton(parent, st.ripple)
-, _text(text)
-, _st(st) {
-	if (_st.width < 0) {
-		_width = textWidth() - _st.width;
-	} else if (!_st.width) {
-		_width = textWidth() + _st.height - _st.font->height;
-	} else {
-		_width = _st.width;
-	}
-	resize(_width, _st.height);
-	Accessibility::SetRole(this, QAccessible::Role::PushButton);
-	setAccessibleName(text);
-}
-
-void FlatButton::setText(const QString &text) {
-	_text = text;
-	setAccessibleName(text);
-	update();
-}
-
-void FlatButton::setWidth(int w) {
-	_width = w;
-	if (_width < 0) {
-		_width = textWidth() - _st.width;
-	} else if (!_width) {
-		_width = textWidth() + _st.height - _st.font->height;
-	}
-	resize(_width, height());
-}
-
-void FlatButton::setColorOverride(std::optional<QColor> color) {
-	_colorOverride = color;
-	update();
-}
-
-int32 FlatButton::textWidth() const {
-	return _st.font->width(_text);
-}
-
-void FlatButton::onStateChanged(State was, StateChangeSource source) {
-	RippleButton::onStateChanged(was, source);
-	update();
-}
-
-void FlatButton::paintEvent(QPaintEvent *e) {
-	QPainter p(this);
-
-	const auto inner = QRect(0, height() - _st.height, width(), _st.height);
-	p.fillRect(inner, isOver() ? _st.overBgColor : _st.bgColor);
-
-	paintRipple(p, 0, 0);
-
-	p.setFont(isOver() ? _st.overFont : _st.font);
-	p.setRenderHint(QPainter::TextAntialiasing);
-	if (_colorOverride) {
-		p.setPen(*_colorOverride);
-	} else {
-		p.setPen(isOver() ? _st.overColor : _st.color);
-	}
-
-	const auto textRect = inner.marginsRemoved(
-		_textMargins
-	).marginsRemoved(
-		{ 0, _st.textTop, 0, 0 }
-	);
-	p.drawText(textRect, _text, style::al_top);
-}
-
-void FlatButton::setTextMargins(QMargins margins) {
-	_textMargins = margins;
-	update();
-}
-
-RoundButton::RoundButton(
-	QWidget *parent,
-	rpl::producer<QString> text,
-	const style::RoundButton &st)
-: RippleButton(parent, st.ripple)
-, _textFull(std::move(text) | rpl::map(Text::WithEntities))
-, _st(st)
-, _roundRect(st.radius ? st.radius : st::buttonRadius, _st.textBg)
-, _roundRectOver(st.radius ? st.radius : st::buttonRadius, _st.textBgOver) {
-	Accessibility::SetRole(this, QAccessible::Role::PushButton);
-	_textFull.value(
-	) | rpl::start_with_next([=](const TextWithEntities &text) {
-		resizeToText(text);
-		setAccessibleName(text.text);
-	}, lifetime());
-}
-
-void RoundButton::setTextTransform(TextTransform transform) {
-	_transform = transform;
-	resizeToText(_textFull.current());
-}
-
-void RoundButton::setText(rpl::producer<QString> text) {
-	_textFull = std::move(text) | rpl::map(Text::WithEntities);
-}
-
-void RoundButton::setText(rpl::producer<TextWithEntities> text) {
-	_textFull = std::move(text);
-}
-
-void RoundButton::setContext(const Text::MarkedContext &context) {
-	_context = context;
-	resizeToText(_textFull.current());
-}
-
-void RoundButton::setNumbersText(const QString &numbersText, int numbers) {
-	if (numbersText.isEmpty()) {
-		_numbers.reset();
-	} else {
-		if (!_numbers) {
-			const auto &font = _st.style.font;
-			_numbers = std::make_unique<NumbersAnimation>(font, [this] {
-				numbersAnimationCallback();
 			});
+		Accessibility::SetRole(this, QAccessible::Role::PushButton);
+	}
+
+	bool CrossButton::loadingCallback(crl::time now) {
+		const auto result = !stopLoadingAnimation(now);
+		if (!result || !anim::Disabled()) {
+			update();
 		}
-		_numbers->setText(numbersText, numbers);
-	}
-	resizeToText(_textFull.current());
-}
-
-void RoundButton::setWidthChangedCallback(Fn<void()> callback) {
-	if (!_numbers) {
-		const auto &font = _st.style.font;
-		_numbers = std::make_unique<NumbersAnimation>(font, [this] {
-			numbersAnimationCallback();
-		});
-	}
-	_numbers->setWidthChangedCallback(std::move(callback));
-}
-
-void RoundButton::setBrushOverride(std::optional<QBrush> brush) {
-	_brushOverride = std::move(brush);
-	update();
-}
-
-void RoundButton::setPenOverride(std::optional<QPen> pen) {
-	_penOverride = std::move(pen);
-	update();
-}
-
-void RoundButton::finishNumbersAnimation() {
-	if (_numbers) {
-		_numbers->finishAnimating();
-	}
-}
-
-void RoundButton::numbersAnimationCallback() {
-	resizeToText(_textFull.current());
-}
-
-void RoundButton::setFullWidth(int newFullWidth) {
-	_fullWidthOverride = newFullWidth;
-	resizeToText(_textFull.current());
-}
-
-void RoundButton::setFullRadius(bool enabled) {
-	_fullRadius = enabled;
-	update();
-}
-
-void RoundButton::resizeToText(const TextWithEntities &text) {
-	if (_transform == TextTransform::ToUpper) {
-		_text.setMarkedText(
-			_st.style,
-			{ text.text.toUpper(), text.entities },
-			kMarkupTextOptions,
-			_context);
-	} else {
-		_text.setMarkedText(_st.style, text, kMarkupTextOptions, _context);
-	}
-	int innerWidth = _text.maxWidth() + addedWidth();
-	if (_fullWidthOverride > 0) {
-		const auto padding = _fullRadius
-			? (_st.padding.left() + _st.padding.right())
-			: 0;
-		resize(
-			_fullWidthOverride + padding,
-			_st.height + _st.padding.top() + _st.padding.bottom());
-	} else if (_fullWidthOverride < 0) {
-		resize(
-			innerWidth - _fullWidthOverride,
-			_st.height + _st.padding.top() + _st.padding.bottom());
-	} else if (_st.width <= 0) {
-		resize(
-			innerWidth - _st.width + _st.padding.left() + _st.padding.right(),
-			_st.height + _st.padding.top() + _st.padding.bottom());
-	} else {
-		resize(
-			_st.width + _st.padding.left() + _st.padding.right(),
-			_st.height + _st.padding.top() + _st.padding.bottom());
-	}
-	setNaturalWidth(width());
-
-	update();
-}
-
-int RoundButton::addedWidth() const {
-	auto result = 0;
-	if (_numbers) {
-		result += (result ? _st.numbersSkip : 0) + _numbers->countWidth();
-	}
-	if (!_st.icon.empty() && _st.iconPosition.x() < 0) {
-		result += _st.icon.width() - _st.iconPosition.x();
-	}
-	return result;
-}
-
-int RoundButton::contentWidth() const {
-	auto result = _text.maxWidth() + addedWidth();
-	if (_fullWidthOverride < 0) {
 		return result;
-	} else if (_fullWidthOverride > 0) {
-		const auto padding = _fullRadius
-			? (_st.padding.left() + _st.padding.right())
-			: 0;
-		const auto delta = _st.height - _st.style.font->height;
-		if (_fullWidthOverride < result + delta) {
-			return std::max(_fullWidthOverride - delta - padding, 1);
+	}
+
+	void CrossButton::toggle(bool visible, anim::type animated) {
+		if (_shown != visible) {
+			_shown = visible;
+			if (animated == anim::type::normal) {
+				if (isHidden()) {
+					setVisible(true);
+				}
+				_showAnimation.start(
+					[=] { animationCallback(); },
+					_shown ? 0. : 1.,
+					_shown ? 1. : 0.,
+					_st.duration);
+			}
+		}
+		if (animated == anim::type::instant) {
+			finishAnimating();
 		}
 	}
-	return std::min(
-		result,
-		width() - _st.padding.left() - _st.padding.right());
-}
 
-void RoundButton::paintEvent(QPaintEvent *e) {
-	Painter p(this);
-
-	auto innerWidth = contentWidth();
-	auto rounded = rect().marginsRemoved(_st.padding);
-	if (_fullWidthOverride < 0) {
-		rounded = QRect(0, rounded.top(), innerWidth - _fullWidthOverride, rounded.height());
-	}
-	const auto drawRect = [&](const RoundRect &rect) {
-		const auto fill = myrtlrect(rounded);
-		if (_fullRadius) {
-			const auto radius = rounded.height() / 2;
-			PainterHighQualityEnabler hq(p);
-			p.setPen(_penOverride ? *_penOverride : Qt::NoPen);
-			p.setBrush(_brushOverride ? *_brushOverride : rect.color()->b);
-			p.drawRoundedRect(fill, radius, radius);
-		} else if (_brushOverride) {
-			PainterHighQualityEnabler hq(p);
-			p.setPen(_penOverride ? *_penOverride : Qt::NoPen);
-			p.setBrush(*_brushOverride);
-			const auto radius = _st.radius ? _st.radius : st::buttonRadius;
-			p.drawRoundedRect(fill, radius, radius);
-		} else {
-			rect.paint(p, fill);
-		}
-	};
-	if (_penOverride) {
-		paintRipple(p, rounded.topLeft());
-	}
-	drawRect(_roundRect);
-
-	auto over = isOver();
-	auto down = isDown();
-	if (!_brushOverride && (over || down)) {
-		drawRect(_roundRectOver);
-	}
-
-	if (!_penOverride) {
-		paintRipple(p, rounded.topLeft());
-	}
-
-	const auto textTop = _st.padding.top() + _st.textTop;
-	auto textLeft = _st.padding.left()
-		+ ((width()
-			- innerWidth
-			- _st.padding.left()
-			- _st.padding.right()) / 2);
-	if (_fullWidthOverride < 0) {
-		textLeft = -_fullWidthOverride / 2;
-	}
-	if (!_st.icon.empty() && _st.iconPosition.x() < 0) {
-		textLeft += _st.icon.width() - _st.iconPosition.x();
-	}
-	const auto iconLeft = (_st.iconPosition.x() >= 0)
-		? _st.iconPosition.x()
-		: (textLeft + _st.iconPosition.x() - _st.icon.width());
-	const auto iconTop = (_st.iconPosition.y() >= 0)
-		? _st.iconPosition.y()
-		: (textTop + _st.iconPosition.y());
-	const auto widthForText = std::max(innerWidth - addedWidth(), 0);
-	if (!_text.isEmpty()) {
-		p.setPen((over || down) ? _st.textFgOver : _st.textFg);
-		_text.draw(p, {
-			.position = { textLeft, textTop },
-			.availableWidth = widthForText,
-			.elisionLines = 1,
-		});
-	}
-	if (_numbers) {
-		textLeft += widthForText + (widthForText ? _st.numbersSkip : 0);
-		p.setFont(_st.style.font);
-		p.setPen((over || down) ? _st.numbersTextFgOver : _st.numbersTextFg);
-		_numbers->paint(p, textLeft, textTop, width());
-	}
-	if (!_st.icon.empty()) {
-		const auto &current = ((over || down) && !_st.iconOver.empty())
-			? _st.iconOver
-			: _st.icon;
-		current.paint(p, QPoint(iconLeft, iconTop), width());
-	}
-}
-
-QImage RoundButton::prepareRippleMask() const {
-	auto innerWidth = contentWidth();
-	auto rounded = style::rtlrect(rect().marginsRemoved(_st.padding), width());
-	if (_fullWidthOverride < 0) {
-		rounded = QRect(0, rounded.top(), innerWidth - _fullWidthOverride, rounded.height());
-	}
-	return RippleAnimation::RoundRectMask(
-		rounded.size(),
-		(_fullRadius
-			? (rounded.height() / 2)
-			: _st.radius
-			? _st.radius
-			: st::buttonRadius));
-}
-
-QPoint RoundButton::prepareRippleStartPosition() const {
-	return mapFromGlobal(QCursor::pos()) - QPoint(_st.padding.left(), _st.padding.top());
-}
-
-RoundButton::~RoundButton() = default;
-
-IconButton::IconButton(QWidget *parent, const style::IconButton &st) : RippleButton(parent, st.ripple)
-, _st(st) {
-	resize(_st.width, _st.height);
-	Accessibility::SetRole(this, QAccessible::Role::PushButton);
-}
-
-const style::IconButton &IconButton::st() const {
-	return _st;
-}
-
-void IconButton::setIconOverride(const style::icon *iconOverride, const style::icon *iconOverOverride) {
-	_iconOverride = iconOverride;
-	_iconOverrideOver = iconOverOverride;
-	update();
-}
-
-void IconButton::setRippleColorOverride(const style::color *colorOverride) {
-	_rippleColorOverride = colorOverride;
-}
-
-float64 IconButton::iconOverOpacity() const {
-	return (isDown() || forceRippled())
-		? 1.
-		: _a_over.value(isOver() ? 1. : 0.);
-}
-
-void IconButton::paintEvent(QPaintEvent *e) {
-	Painter p(this);
-
-	paintRipple(p, _st.rippleAreaPosition, _rippleColorOverride ? &(*_rippleColorOverride)->c : nullptr);
-
-	const auto overIconOpacity = iconOverOpacity();
-	const auto overIcon = [&] {
-		if (_iconOverrideOver) {
-			return _iconOverrideOver;
-		} else if (!_st.iconOver.empty()) {
-			return &_st.iconOver;
-		} else if (_iconOverride) {
-			return _iconOverride;
-		}
-		return &_st.icon;
-	};
-	const auto justIcon = [&] {
-		if (_iconOverride) {
-			return _iconOverride;
-		}
-		return &_st.icon;
-	};
-	const auto icon = (overIconOpacity == 1.) ? overIcon() : justIcon();
-	auto position = _st.iconPosition;
-	if (position.x() < 0) {
-		position.setX((width() - icon->width()) / 2);
-	}
-	if (position.y() < 0) {
-		position.setY((height() - icon->height()) / 2);
-	}
-	icon->paint(p, position, width());
-	if (overIconOpacity > 0. && overIconOpacity < 1.) {
-		const auto iconOver = overIcon();
-		if (iconOver != icon) {
-			p.setOpacity(overIconOpacity);
-			iconOver->paint(p, position, width());
+	void CrossButton::animationCallback() {
+		update();
+		if (!_showAnimation.animating()) {
+			setVisible(_shown);
 		}
 	}
-}
 
-void IconButton::onStateChanged(State was, StateChangeSource source) {
-	RippleButton::onStateChanged(was, source);
+	void CrossButton::paintEvent(QPaintEvent* e) {
+		auto p = QPainter(this);
 
-	auto over = isOver();
-	auto wasOver = static_cast<bool>(was & StateFlag::Over);
-	if (over != wasOver) {
-		if (_st.duration) {
-			auto from = over ? 0. : 1.;
-			auto to = over ? 1. : 0.;
-			_a_over.start([this] { update(); }, from, to, _st.duration);
-		} else {
+		auto over = isOver();
+		auto shown = _showAnimation.value(_shown ? 1. : 0.);
+		p.setOpacity(shown);
+
+		paintRipple(p, _st.crossPosition);
+
+		auto loading = 0.;
+		if (_loadingAnimation.animating()) {
+			const auto now = crl::now();
+			if (stopLoadingAnimation(now)) {
+				_loadingAnimation.stop();
+			}
+			else if (anim::Disabled()) {
+				CrossAnimation::paintStaticLoading(
+					p,
+					_st.cross,
+					over ? _st.crossFgOver : _st.crossFg,
+					_st.crossPosition.x(),
+					_st.crossPosition.y(),
+					width(),
+					shown);
+				return;
+			}
+			else {
+				loading = ((now - _loadingAnimation.started())
+					% _st.loadingPeriod) / float64(_st.loadingPeriod);
+			}
+		}
+		CrossAnimation::paint(
+			p,
+			_st.cross,
+			over ? _st.crossFgOver : _st.crossFg,
+			_st.crossPosition.x(),
+			_st.crossPosition.y(),
+			width(),
+			shown,
+			loading);
+	}
+
+	bool CrossButton::stopLoadingAnimation(crl::time now) {
+		if (!_loadingStopMs) {
+			return false;
+		}
+		const auto stopPeriod = (_loadingStopMs - _loadingAnimation.started())
+			/ _st.loadingPeriod;
+		const auto currentPeriod = (now - _loadingAnimation.started())
+			/ _st.loadingPeriod;
+		if (currentPeriod != stopPeriod) {
+			Assert(currentPeriod > stopPeriod);
+			return true;
+		}
+		return false;
+	}
+
+	void CrossButton::setLoadingAnimation(bool enabled) {
+		if (enabled) {
+			_loadingStopMs = 0;
+			if (!_loadingAnimation.animating()) {
+				_loadingAnimation.start();
+			}
+		}
+		else if (_loadingAnimation.animating()) {
+			_loadingStopMs = crl::now();
+			if (!((_loadingStopMs - _loadingAnimation.started())
+				% _st.loadingPeriod)) {
+				_loadingAnimation.stop();
+			}
+		}
+		if (anim::Disabled()) {
 			update();
 		}
 	}
-}
 
-QPoint IconButton::prepareRippleStartPosition() const {
-	auto result = mapFromGlobal(QCursor::pos())
-		- _st.rippleAreaPosition;
-	auto rect = QRect(0, 0, _st.rippleAreaSize, _st.rippleAreaSize);
-	return rect.contains(result)
-		? result
-		: DisabledRippleStartPosition();
-}
+	void CrossButton::onStateChanged(State was, StateChangeSource source) {
+		RippleButton::onStateChanged(was, source);
 
-QImage IconButton::prepareRippleMask() const {
-	return RippleAnimation::EllipseMask(QSize(_st.rippleAreaSize, _st.rippleAreaSize));
-}
-
-CrossButton::CrossButton(QWidget *parent, const style::CrossButton &st) : RippleButton(parent, st.ripple)
-, _st(st)
-, _loadingAnimation([=](crl::time now) { return loadingCallback(now); }) {
-	resize(_st.width, _st.height);
-	setCursor(style::cur_pointer);
-	setVisible(false);
-	Accessibility::SetRole(this, QAccessible::Role::PushButton);
-}
-
-bool CrossButton::loadingCallback(crl::time now) {
-	const auto result = !stopLoadingAnimation(now);
-	if (!result || !anim::Disabled()) {
-		update();
+		auto over = isOver();
+		auto wasOver = static_cast<bool>(was & StateFlag::Over);
+		if (over != wasOver) {
+			update();
+		}
 	}
-	return result;
-}
 
-void CrossButton::toggle(bool visible, anim::type animated) {
-	if (_shown != visible) {
-		_shown = visible;
-		if (animated == anim::type::normal) {
-			if (isHidden()) {
-				setVisible(true);
+	QPoint CrossButton::prepareRippleStartPosition() const {
+		return mapFromGlobal(QCursor::pos()) - _st.crossPosition;
+	}
+
+	QImage CrossButton::prepareRippleMask() const {
+		return RippleAnimation::EllipseMask(QSize(_st.cross.size, _st.cross.size));
+	}
+
+	SettingsButton::SettingsButton(
+		QWidget* parent,
+		rpl::producer<QString>&& text,
+		const style::SettingsButton& st)
+		: SettingsButton(parent, std::move(text) | rpl::map([=](QString&& text) {
+		return TextWithEntities{ std::move(text) };
+			}), st) {
+	}
+
+	SettingsButton::SettingsButton(
+		QWidget* parent,
+		rpl::producer<TextWithEntities>&& text,
+		const style::SettingsButton& st,
+		const Text::MarkedContext& context)
+		: RippleButton(parent, st.ripple)
+		, _st(st)
+		, _padding(_st.padding)
+		, _context(context) {
+		Accessibility::ObserveScreenReaderState(this, [this](bool isActive) {
+			if (isActive) {
+				setFocusPolicy(Qt::StrongFocus);
 			}
-			_showAnimation.start(
-				[=] { animationCallback(); },
-				_shown ? 0. : 1.,
-				_shown ? 1. : 0.,
-				_st.duration);
+			else {
+				setFocusPolicy(Qt::NoFocus);
+			}
+			});
+		Accessibility::SetRole(this, QAccessible::Role::PushButton);
+		std::move(
+			text
+		) | rpl::start_with_next([this](TextWithEntities&& value) {
+			setText(std::move(value));
+			}, lifetime());
+	}
+
+	SettingsButton::SettingsButton(
+		QWidget* parent,
+		nullptr_t,
+		const style::SettingsButton& st)
+		: RippleButton(parent, st.ripple)
+		, _st(st)
+		, _padding(_st.padding) {
+		Accessibility::ObserveScreenReaderState(this, [this](bool isActive) {
+			if (isActive) {
+				setFocusPolicy(Qt::StrongFocus);
+			}
+			else {
+				setFocusPolicy(Qt::NoFocus);
+			}
+			});
+		Accessibility::SetRole(this, QAccessible::Role::PushButton);
+	}
+
+	SettingsButton::~SettingsButton() = default;
+
+	void SettingsButton::finishAnimating() {
+		if (_toggle) {
+			_toggle->finishAnimating();
 		}
+		Ui::RippleButton::finishAnimating();
 	}
-	if (animated == anim::type::instant) {
-		finishAnimating();
-	}
-}
 
-void CrossButton::animationCallback() {
-	update();
-	if (!_showAnimation.animating()) {
-		setVisible(_shown);
-	}
-}
-
-void CrossButton::paintEvent(QPaintEvent *e) {
-	auto p = QPainter(this);
-
-	auto over = isOver();
-	auto shown = _showAnimation.value(_shown ? 1. : 0.);
-	p.setOpacity(shown);
-
-	paintRipple(p, _st.crossPosition);
-
-	auto loading = 0.;
-	if (_loadingAnimation.animating()) {
-		const auto now = crl::now();
-		if (stopLoadingAnimation(now)) {
-			_loadingAnimation.stop();
-		} else if (anim::Disabled()) {
-			CrossAnimation::paintStaticLoading(
-				p,
-				_st.cross,
-				over ? _st.crossFgOver : _st.crossFg,
-				_st.crossPosition.x(),
-				_st.crossPosition.y(),
-				width(),
-				shown);
-			return;
-		} else {
-			loading = ((now - _loadingAnimation.started())
-				% _st.loadingPeriod) / float64(_st.loadingPeriod);
-		}
-	}
-	CrossAnimation::paint(
-		p,
-		_st.cross,
-		over ? _st.crossFgOver : _st.crossFg,
-		_st.crossPosition.x(),
-		_st.crossPosition.y(),
-		width(),
-		shown,
-		loading);
-}
-
-bool CrossButton::stopLoadingAnimation(crl::time now) {
-	if (!_loadingStopMs) {
-		return false;
-	}
-	const auto stopPeriod = (_loadingStopMs - _loadingAnimation.started())
-		/ _st.loadingPeriod;
-	const auto currentPeriod = (now - _loadingAnimation.started())
-		/ _st.loadingPeriod;
-	if (currentPeriod != stopPeriod) {
-		Assert(currentPeriod > stopPeriod);
-		return true;
-	}
-	return false;
-}
-
-void CrossButton::setLoadingAnimation(bool enabled) {
-	if (enabled) {
-		_loadingStopMs = 0;
-		if (!_loadingAnimation.animating()) {
-			_loadingAnimation.start();
-		}
-	} else if (_loadingAnimation.animating()) {
-		_loadingStopMs = crl::now();
-		if (!((_loadingStopMs - _loadingAnimation.started())
-			% _st.loadingPeriod)) {
-			_loadingAnimation.stop();
-		}
-	}
-	if (anim::Disabled()) {
-		update();
-	}
-}
-
-void CrossButton::onStateChanged(State was, StateChangeSource source) {
-	RippleButton::onStateChanged(was, source);
-
-	auto over = isOver();
-	auto wasOver = static_cast<bool>(was & StateFlag::Over);
-	if (over != wasOver) {
-		update();
-	}
-}
-
-QPoint CrossButton::prepareRippleStartPosition() const {
-	return mapFromGlobal(QCursor::pos()) - _st.crossPosition;
-}
-
-QImage CrossButton::prepareRippleMask() const {
-	return RippleAnimation::EllipseMask(QSize(_st.cross.size, _st.cross.size));
-}
-
-SettingsButton::SettingsButton(
-	QWidget *parent,
-	rpl::producer<QString> &&text,
-	const style::SettingsButton &st)
-: SettingsButton(parent, std::move(text) | rpl::map([=](QString &&text) {
-	return TextWithEntities{ std::move(text) };
-}), st) {
-}
-
-SettingsButton::SettingsButton(
-	QWidget *parent,
-	rpl::producer<TextWithEntities> &&text,
-	const style::SettingsButton &st,
-	const Text::MarkedContext &context)
-: RippleButton(parent, st.ripple)
-, _st(st)
-, _padding(_st.padding)
-, _context(context) {
-	Accessibility::SetRole(this, QAccessible::Role::PushButton);
-	std::move(
-		text
-	) | rpl::start_with_next([this](TextWithEntities &&value) {
-		setText(std::move(value));
-	}, lifetime());
-}
-
-SettingsButton::SettingsButton(
-	QWidget *parent,
-	nullptr_t,
-	const style::SettingsButton &st)
-: RippleButton(parent, st.ripple)
-, _st(st)
-, _padding(_st.padding) {
-	Accessibility::SetRole(this, QAccessible::Role::PushButton);
-}
-
-SettingsButton::~SettingsButton() = default;
-
-void SettingsButton::finishAnimating() {
-	if (_toggle) {
-		_toggle->finishAnimating();
-	}
-	Ui::RippleButton::finishAnimating();
-}
-
-SettingsButton *SettingsButton::toggleOn(
-		rpl::producer<bool> &&toggled,
+	SettingsButton* SettingsButton::toggleOn(
+		rpl::producer<bool>&& toggled,
 		bool ignoreClick) {
-	Expects(_toggle == nullptr);
+		Expects(_toggle == nullptr);
 
-	_toggle = std::make_unique<Ui::ToggleView>(
-		isOver() ? _st.toggleOver : _st.toggle,
-		false,
-		[this] { rtlupdate(toggleRect()); });
-	if (!ignoreClick) {
-		addClickHandler([this] {
-			_toggle->setChecked(!_toggle->checked(), anim::type::normal);
-		});
+		_toggle = std::make_unique<Ui::ToggleView>(
+			isOver() ? _st.toggleOver : _st.toggle,
+			false,
+			[this] { rtlupdate(toggleRect()); });
+		if (!ignoreClick) {
+			addClickHandler([this] {
+				_toggle->setChecked(!_toggle->checked(), anim::type::normal);
+				});
+		}
+		std::move(
+			toggled
+		) | rpl::start_with_next([this](bool toggled) {
+			_toggle->setChecked(toggled, anim::type::normal);
+			}, lifetime());
+		_toggle->finishAnimating();
+		return this;
 	}
-	std::move(
-		toggled
-	) | rpl::start_with_next([this](bool toggled) {
-		_toggle->setChecked(toggled, anim::type::normal);
-	}, lifetime());
-	_toggle->finishAnimating();
-	return this;
-}
 
-bool SettingsButton::toggled() const {
-	return _toggle ? _toggle->checked() : false;
-}
-
-void SettingsButton::setToggleLocked(bool locked) {
-	if (_toggle) {
-		_toggle->setLocked(locked);
+	bool SettingsButton::toggled() const {
+		return _toggle ? _toggle->checked() : false;
 	}
-}
 
-rpl::producer<bool> SettingsButton::toggledChanges() const {
-	if (_toggle) {
-		return _toggle->checkedChanges();
+	void SettingsButton::setToggleLocked(bool locked) {
+		if (_toggle) {
+			_toggle->setLocked(locked);
+		}
 	}
-	return nullptr;
-}
 
-rpl::producer<bool> SettingsButton::toggledValue() const {
-	if (_toggle) {
-		return _toggle->checkedValue();
+	rpl::producer<bool> SettingsButton::toggledChanges() const {
+		if (_toggle) {
+			return _toggle->checkedChanges();
+		}
+		return nullptr;
 	}
-	return nullptr;
-}
 
-void SettingsButton::setColorOverride(
+	rpl::producer<bool> SettingsButton::toggledValue() const {
+		if (_toggle) {
+			return _toggle->checkedValue();
+		}
+		return nullptr;
+	}
+
+	void SettingsButton::setColorOverride(
 		std::optional<QColor> textColorOverride) {
-	_textColorOverride = textColorOverride;
-	update();
-}
-
-void SettingsButton::setPaddingOverride(style::margins padding) {
-	_padding = padding;
-	resizeToWidth(widthNoMargins());
-}
-
-const style::SettingsButton &SettingsButton::st() const {
-	return _st;
-}
-
-int SettingsButton::fullTextWidth() const {
-	return _text.maxWidth();
-}
-
-void SettingsButton::paintEvent(QPaintEvent *e) {
-	Painter p(this);
-
-	const auto paintOver = (isOver() || isDown()) && !isDisabled();
-	paintBg(p, e->rect(), paintOver);
-
-	paintRipple(p, 0, 0);
-
-	const auto outerw = width();
-	paintText(p, paintOver, outerw);
-
-	if (_toggle) {
-		paintToggle(p, outerw);
+		_textColorOverride = textColorOverride;
+		update();
 	}
-}
 
-void SettingsButton::paintBg(Painter &p, const QRect &rect, bool over) const {
-	p.fillRect(rect, over ? _st.textBgOver : _st.textBg);
-}
-
-void SettingsButton::paintText(Painter &p, bool over, int outerw) const {
-	auto available = outerw - _padding.left() - _padding.right();
-	if (_toggle) {
-		available -= (width() - toggleRect().x());
+	void SettingsButton::setPaddingOverride(style::margins padding) {
+		_padding = padding;
+		resizeToWidth(widthNoMargins());
 	}
-	if (available <= 0) {
-		return;
+
+	const style::SettingsButton& SettingsButton::st() const {
+		return _st;
 	}
-	p.setPen(_textColorOverride
-		? QPen(*_textColorOverride)
-		: over
-		? _st.textFgOver
-		: _st.textFg);
-	_text.drawLeftElided(
-		p,
-		_padding.left(),
-		_padding.top(),
-		available,
-		outerw);
-}
 
-void SettingsButton::paintToggle(Painter &p, int outerw) const {
-	if (_toggle) {
-		auto rect = toggleRect();
-		_toggle->paint(p, rect.left(), rect.top(), outerw);
+	int SettingsButton::fullTextWidth() const {
+		return _text.maxWidth();
 	}
-}
 
-QRect SettingsButton::toggleRect() const {
-	Expects(_toggle != nullptr);
+	void SettingsButton::paintEvent(QPaintEvent* e) {
+		Painter p(this);
 
-	auto size = _toggle->getSize();
-	auto left = width() - _st.toggleSkip - size.width();
-	auto top = (height() - size.height()) / 2;
-	return { QPoint(left, top), size };
-}
+		const auto paintOver = (isOver() || isDown()) && !isDisabled();
+		paintBg(p, e->rect(), paintOver);
 
-QRect SettingsButton::maybeToggleRect() const {
-	return _toggle ? toggleRect() : QRect(0, 0, 0, 0);
-}
+		paintRipple(p, 0, 0);
 
-int SettingsButton::resizeGetHeight(int newWidth) {
-	return _padding.top() + _st.height + _padding.bottom();
-}
+		const auto outerw = width();
+		paintText(p, paintOver, outerw);
 
-void SettingsButton::onStateChanged(
+		if (_toggle) {
+			paintToggle(p, outerw);
+		}
+	}
+
+	void SettingsButton::paintBg(Painter& p, const QRect& rect, bool over) const {
+		p.fillRect(rect, over ? _st.textBgOver : _st.textBg);
+	}
+
+	void SettingsButton::paintText(Painter& p, bool over, int outerw) const {
+		auto available = outerw - _padding.left() - _padding.right();
+		if (_toggle) {
+			available -= (width() - toggleRect().x());
+		}
+		if (available <= 0) {
+			return;
+		}
+		p.setPen(_textColorOverride
+			? QPen(*_textColorOverride)
+			: over
+			? _st.textFgOver
+			: _st.textFg);
+		_text.drawLeftElided(
+			p,
+			_padding.left(),
+			_padding.top(),
+			available,
+			outerw);
+	}
+
+	void SettingsButton::paintToggle(Painter& p, int outerw) const {
+		if (_toggle) {
+			auto rect = toggleRect();
+			_toggle->paint(p, rect.left(), rect.top(), outerw);
+		}
+	}
+
+	QRect SettingsButton::toggleRect() const {
+		Expects(_toggle != nullptr);
+
+		auto size = _toggle->getSize();
+		auto left = width() - _st.toggleSkip - size.width();
+		auto top = (height() - size.height()) / 2;
+		return { QPoint(left, top), size };
+	}
+
+	QRect SettingsButton::maybeToggleRect() const {
+		return _toggle ? toggleRect() : QRect(0, 0, 0, 0);
+	}
+
+	int SettingsButton::resizeGetHeight(int newWidth) {
+		return _padding.top() + _st.height + _padding.bottom();
+	}
+
+	void SettingsButton::onStateChanged(
 		State was,
 		StateChangeSource source) {
-	if (!isDisabled() || !isDown()) {
-		RippleButton::onStateChanged(was, source);
-	}
-	if (_toggle) {
-		_toggle->setStyle(isOver() ? _st.toggleOver : _st.toggle);
-	}
-	setPointerCursor(!isDisabled());
-}
-
-void SettingsButton::setText(TextWithEntities &&text) {
-	_text.setMarkedText(_st.style, text, kMarkupTextOptions, _context);
-	setAccessibleName(text.text);
-	update();
-}
-
-not_null<RippleButton*> CreateSimpleRectButton(
-		QWidget *parent,
-		const style::RippleAnimation &st) {
-	const auto result = CreateChild<SimpleRippleButton>(parent, st);
-	result->paintRequest() | rpl::start_with_next([result] {
-		auto p = QPainter(result);
-		result->paintRipple(p, 0, 0);
-	}, result->lifetime());
-	return result;
-}
-
-not_null<RippleButton*> CreateSimpleSettingsButton(
-		QWidget *parent,
-		const style::RippleAnimation &st,
-		const style::color &bg) {
-	const auto result = CreateChild<SimpleRippleButton>(parent, st);
-	result->paintRequest() | rpl::start_with_next([result, bg] {
-		auto p = QPainter(result);
-		const auto paintOver = (result->isOver() || result->isDown())
-			&& !result->isDisabled();
-		if (paintOver) {
-			p.fillRect(result->rect(), bg);
+		if (!isDisabled() || !isDown()) {
+			RippleButton::onStateChanged(was, source);
 		}
-		result->paintRipple(p, 0, 0);
-	}, result->lifetime());
-	return result;
-}
+		if (_toggle) {
+			_toggle->setStyle(isOver() ? _st.toggleOver : _st.toggle);
+		}
+		setPointerCursor(!isDisabled());
+	}
 
-not_null<RippleButton*> CreateSimpleCircleButton(
-		QWidget *parent,
-		const style::RippleAnimation &st) {
-	const auto result = CreateChild<SimpleCircleButton>(parent, st);
-	result->paintRequest() | rpl::start_with_next([result] {
-		auto p = QPainter(result);
-		result->paintRipple(p, 0, 0);
-	}, result->lifetime());
-	return result;
-}
+	void SettingsButton::setText(TextWithEntities&& text) {
+		_text.setMarkedText(_st.style, text, kMarkupTextOptions, _context);
+		setAccessibleName(text.text);
+		update();
+	}
 
-not_null<RippleButton*> CreateSimpleRoundButton(
-		QWidget *parent,
-		const style::RippleAnimation &st) {
-	const auto result = CreateChild<SimpleRoundButton>(parent, st);
-	result->paintRequest() | rpl::start_with_next([result] {
-		auto p = QPainter(result);
-		result->paintRipple(p, 0, 0);
-	}, result->lifetime());
-	return result;
-}
+	not_null<RippleButton*> CreateSimpleRectButton(
+		QWidget* parent,
+		const style::RippleAnimation& st) {
+		const auto result = CreateChild<SimpleRippleButton>(parent, st);
+		result->paintRequest() | rpl::start_with_next([result] {
+			auto p = QPainter(result);
+			result->paintRipple(p, 0, 0);
+			}, result->lifetime());
+		return result;
+	}
+
+	not_null<RippleButton*> CreateSimpleSettingsButton(
+		QWidget* parent,
+		const style::RippleAnimation& st,
+		const style::color& bg) {
+		const auto result = CreateChild<SimpleRippleButton>(parent, st);
+		result->paintRequest() | rpl::start_with_next([result, bg] {
+			auto p = QPainter(result);
+			const auto paintOver = (result->isOver() || result->isDown())
+				&& !result->isDisabled();
+			if (paintOver) {
+				p.fillRect(result->rect(), bg);
+			}
+			result->paintRipple(p, 0, 0);
+			}, result->lifetime());
+		return result;
+	}
+
+	not_null<RippleButton*> CreateSimpleCircleButton(
+		QWidget* parent,
+		const style::RippleAnimation& st) {
+		const auto result = CreateChild<SimpleCircleButton>(parent, st);
+		result->paintRequest() | rpl::start_with_next([result] {
+			auto p = QPainter(result);
+			result->paintRipple(p, 0, 0);
+			}, result->lifetime());
+		return result;
+	}
+
+	not_null<RippleButton*> CreateSimpleRoundButton(
+		QWidget* parent,
+		const style::RippleAnimation& st) {
+		const auto result = CreateChild<SimpleRoundButton>(parent, st);
+		result->paintRequest() | rpl::start_with_next([result] {
+			auto p = QPainter(result);
+			result->paintRipple(p, 0, 0);
+			}, result->lifetime());
+		return result;
+	}
 
 } // namespace Ui

--- a/ui/widgets/buttons.cpp
+++ b/ui/widgets/buttons.cpp
@@ -70,8 +70,8 @@ LinkButton::LinkButton(
 , _textWidth(st.font->width(_text)) {
 	resizeToText();
 	setCursor(style::cur_pointer);
-	Accessibility::SetName(this, _text);
 	Accessibility::SetRole(this, QAccessible::Role::Link);
+	setAccessibleName(text);
 }
 
 void LinkButton::paintEvent(QPaintEvent *e) {
@@ -98,9 +98,9 @@ void LinkButton::paintEvent(QPaintEvent *e) {
 void LinkButton::setText(const QString &text) {
 	_text = text;
 	_textWidth = _st.font->width(_text);
+	setAccessibleName(text);
 	resizeToText();
 	update();
-	Accessibility::SetName(this, _text);
 }
 
 void LinkButton::resizeToText() {
@@ -237,14 +237,14 @@ FlatButton::FlatButton(
 		_width = _st.width;
 	}
 	resize(_width, _st.height);
-	Accessibility::SetName(this, _text);
 	Accessibility::SetRole(this, QAccessible::Role::PushButton);
+	setAccessibleName(text);
 }
 
 void FlatButton::setText(const QString &text) {
 	_text = text;
+	setAccessibleName(text);
 	update();
-	Accessibility::SetName(this, _text);
 }
 
 void FlatButton::setWidth(int w) {
@@ -309,12 +309,12 @@ RoundButton::RoundButton(
 , _st(st)
 , _roundRect(st.radius ? st.radius : st::buttonRadius, _st.textBg)
 , _roundRectOver(st.radius ? st.radius : st::buttonRadius, _st.textBgOver) {
+	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 	_textFull.value(
 	) | rpl::start_with_next([=](const TextWithEntities &text) {
 		resizeToText(text);
-		Accessibility::SetName(this, text.text);
+		setAccessibleName(text.text);
 	}, lifetime());
-	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 }
 
 void RoundButton::setTextTransform(TextTransform transform) {
@@ -805,12 +805,12 @@ SettingsButton::SettingsButton(
 , _st(st)
 , _padding(_st.padding)
 , _context(context) {
+	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 	std::move(
 		text
 	) | rpl::start_with_next([this](TextWithEntities &&value) {
 		setText(std::move(value));
 	}, lifetime());
-	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 }
 
 SettingsButton::SettingsButton(
@@ -977,8 +977,8 @@ void SettingsButton::onStateChanged(
 
 void SettingsButton::setText(TextWithEntities &&text) {
 	_text.setMarkedText(_st.style, text, kMarkupTextOptions, _context);
+	setAccessibleName(text.text);
 	update();
-	Accessibility::SetName(this, text.text);
 }
 
 not_null<RippleButton*> CreateSimpleRectButton(

--- a/ui/widgets/buttons.cpp
+++ b/ui/widgets/buttons.cpp
@@ -15,6 +15,8 @@
 #include "ui/painter.h"
 #include "ui/qt_object_factory.h"
 
+#include "base/platform/base_accessibility.h"
+
 #include <QtGui/QtEvents>
 
 namespace Ui {
@@ -68,6 +70,8 @@ LinkButton::LinkButton(
 , _textWidth(st.font->width(_text)) {
 	resizeToText();
 	setCursor(style::cur_pointer);
+	Accessibility::SetName(this, _text);
+	Accessibility::SetRole(this, QAccessible::Role::Link);
 }
 
 void LinkButton::paintEvent(QPaintEvent *e) {
@@ -96,6 +100,7 @@ void LinkButton::setText(const QString &text) {
 	_textWidth = _st.font->width(_text);
 	resizeToText();
 	update();
+	Accessibility::SetName(this, _text);
 }
 
 void LinkButton::resizeToText() {
@@ -232,11 +237,14 @@ FlatButton::FlatButton(
 		_width = _st.width;
 	}
 	resize(_width, _st.height);
+	Accessibility::SetName(this, _text);
+	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 }
 
 void FlatButton::setText(const QString &text) {
 	_text = text;
 	update();
+	Accessibility::SetName(this, _text);
 }
 
 void FlatButton::setWidth(int w) {
@@ -304,7 +312,9 @@ RoundButton::RoundButton(
 	_textFull.value(
 	) | rpl::start_with_next([=](const TextWithEntities &text) {
 		resizeToText(text);
+		Accessibility::SetName(this, text.text);
 	}, lifetime());
+	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 }
 
 void RoundButton::setTextTransform(TextTransform transform) {
@@ -551,6 +561,7 @@ RoundButton::~RoundButton() = default;
 IconButton::IconButton(QWidget *parent, const style::IconButton &st) : RippleButton(parent, st.ripple)
 , _st(st) {
 	resize(_st.width, _st.height);
+	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 }
 
 const style::IconButton &IconButton::st() const {
@@ -648,6 +659,7 @@ CrossButton::CrossButton(QWidget *parent, const style::CrossButton &st) : Ripple
 	resize(_st.width, _st.height);
 	setCursor(style::cur_pointer);
 	setVisible(false);
+	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 }
 
 bool CrossButton::loadingCallback(crl::time now) {
@@ -798,6 +810,7 @@ SettingsButton::SettingsButton(
 	) | rpl::start_with_next([this](TextWithEntities &&value) {
 		setText(std::move(value));
 	}, lifetime());
+	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 }
 
 SettingsButton::SettingsButton(
@@ -807,6 +820,7 @@ SettingsButton::SettingsButton(
 : RippleButton(parent, st.ripple)
 , _st(st)
 , _padding(_st.padding) {
+	Accessibility::SetRole(this, QAccessible::Role::PushButton);
 }
 
 SettingsButton::~SettingsButton() = default;
@@ -964,6 +978,7 @@ void SettingsButton::onStateChanged(
 void SettingsButton::setText(TextWithEntities &&text) {
 	_text.setMarkedText(_st.style, text, kMarkupTextOptions, _context);
 	update();
+	Accessibility::SetName(this, text.text);
 }
 
 not_null<RippleButton*> CreateSimpleRectButton(

--- a/ui/widgets/fields/input_field.cpp
+++ b/ui/widgets/fields/input_field.cpp
@@ -1568,6 +1568,7 @@ InputField::InputField(
 	_placeholderFull.value(
 	) | rpl::start_with_next([=](const QString &text) {
 		refreshPlaceholder(text);
+		setAccessibleName(text);
 	}, lifetime());
 
 	style::PaletteChanged(

--- a/ui/widgets/fields/masked_input_field.cpp
+++ b/ui/widgets/fields/masked_input_field.cpp
@@ -73,6 +73,7 @@ MaskedInputField::MaskedInputField(
 	_placeholderFull.value(
 	) | rpl::start_with_next([=](const QString &text) {
 		refreshPlaceholder(text);
+		setAccessibleName(text);
 	}, lifetime());
 
 	style::PaletteChanged(

--- a/ui/widgets/labels.cpp
+++ b/ui/widgets/labels.cpp
@@ -7,6 +7,7 @@
 #include "ui/widgets/labels.h"
 
 #include "base/invoke_queued.h"
+#include "base/platform/base_accessibility.h"
 #include "ui/text/text_entity.h"
 #include "ui/effects/animation_value.h"
 #include "ui/widgets/popup_menu.h"
@@ -205,6 +206,7 @@ FlatLabel::FlatLabel(
 , _st(st)
 , _stMenu(stMenu) {
 	init();
+	Accessibility::SetRole(this, QAccessible::Role::StaticText);
 }
 
 FlatLabel::FlatLabel(
@@ -218,6 +220,8 @@ FlatLabel::FlatLabel(
 , _stMenu(stMenu) {
 	setText(text);
 	init();
+	Accessibility::SetRole(this, QAccessible::Role::StaticText);
+	setAccessibleName(text);
 }
 
 FlatLabel::FlatLabel(
@@ -230,10 +234,12 @@ FlatLabel::FlatLabel(
 , _st(st)
 , _stMenu(stMenu) {
 	textUpdated();
+	Accessibility::SetRole(this, QAccessible::Role::StaticText);
 	std::move(
 		text
 	) | rpl::start_with_next([this](const QString &value) {
 		setText(value);
+		setAccessibleName(value);
 	}, lifetime());
 	init();
 }
@@ -251,10 +257,12 @@ FlatLabel::FlatLabel(
 , _touchSelectTimer([=] { touchSelect(); }) {
 	textUpdated();
 
+	Accessibility::SetRole(this, QAccessible::Role::StaticText);
 	std::move(
 		text
 	) | rpl::start_with_next([=](const TextWithEntities &value) {
 		setMarkedText(value, context);
+		setAccessibleName(value.text);
 	}, lifetime());
 	init();
 }
@@ -277,6 +285,7 @@ void FlatLabel::textUpdated() {
 
 void FlatLabel::setText(const QString &text) {
 	_text.setText(_st.style, text, _labelOptions);
+	setAccessibleName(text);
 	textUpdated();
 }
 
@@ -289,6 +298,7 @@ void FlatLabel::setMarkedText(
 		textWithEntities,
 		_labelMarkedOptions,
 		context);
+	setAccessibleName(textWithEntities.text);
 	textUpdated();
 }
 


### PR DESCRIPTION
This PR introduces initial accessibility improvements in lib_ui by assigning meaningful accessibility roles and names to key widgets:
• 
Label: added accessible name to ensure screen readers can announce text labels properly.
• 
Button: set accessibility role and name so navigation is clear for screen reader users.
• 
Field (input widgets): added role and name, making text fields recognizable and their purpose clear.
These changes improve the screen reader experience (tested with NVDA) and are part of the ongoing effort to make Telegram Desktop more accessible.
If this direction is welcomed, I will continue extending accessibility improvements in other parts of Telegram Desktop.