### PR TITLE
Fix build errors related to std::nullptr_t

### DIFF
--- a/ui/widgets/buttons.cpp
+++ b/ui/widgets/buttons.cpp
@@ -802,7 +802,7 @@ SettingsButton::SettingsButton(
 
 SettingsButton::SettingsButton(
 	QWidget *parent,
-	nullptr_t,
+	std::nullptr_t,
 	const style::SettingsButton &st)
 : RippleButton(parent, st.ripple)
 , _st(st)

--- a/ui/widgets/buttons.h
+++ b/ui/widgets/buttons.h
@@ -12,6 +12,7 @@
 #include "ui/text/text.h"
 #include "styles/style_widgets.h"
 
+#include <cstddef>
 #include <memory>
 
 class Painter;
@@ -276,7 +277,7 @@ public:
 		const Text::MarkedContext &context = {});
 	SettingsButton(
 		QWidget *parent,
-		nullptr_t,
+		std::nullptr_t,
 		const style::SettingsButton &st = st::defaultSettingsButton);
 	~SettingsButton();
 


### PR DESCRIPTION
When building on Alpine Linux, a build error is produced due to nullptr_t being undefined. Importing <cstddef> fixes this.

It is unclear why the build error is not reproducible elsewhere; it may be due to different build flags or subtle differences in dependencies.

Regardless, usage of nullptr_t requires importing <cstddef>, so this change is correct everywhere, even if it is a no-op on some build configurations.