### PR TITLE
Fix excessive combining marks causing GPU overload and rendering corruption

### DIFF
--- a/ui/text/text.cpp
+++ b/ui/text/text.cpp
@@ -2011,8 +2011,11 @@ bool IsSpace(QChar ch) {
 		|| (ch == QChar::Tabulation);
 }
 
-bool IsDiacritic(QChar ch) { // diacritic and variation selectors
-	return (ch.category() == QChar::Mark_NonSpacing)
+bool IsDiacritic(QChar ch) { // diacritic, combining and variation selectors
+	const auto category = ch.category();
+	return (category == QChar::Mark_NonSpacing)
+		|| (category == QChar::Mark_Enclosing)
+		|| (category == QChar::Mark_SpacingCombining)
 		|| (ch.unicode() == 1652)
 		|| (ch.unicode() >= 64606 && ch.unicode() <= 64611);
 }


### PR DESCRIPTION
# Fix excessive combining marks causing GPU overload and rendering corruption

## Problem

Text containing a large number of Unicode combining characters (such as `⃝` U+20DD COMBINING ENCLOSING CIRCLE) stacked on a single base character causes:

1. **GPU overload** — the text renderer tries to draw hundreds/thousands of overlapping glyphs for a single character
2. **Incorrect display** — the rendered text appears as visual noise/garbage

Example of malicious text: `ы҉⃝` repeated hundreds of times — a single Cyrillic letter with COMBINING CYRILLIC MILLIONS SIGN (U+0489, Mark_NonSpacing) followed by COMBINING ENCLOSING CIRCLE (U+20DD, Mark_Enclosing).

## Root Cause

The `IsDiacritic()` function in `ui/text/text.cpp` only checked for `QChar::Mark_NonSpacing` category. While the block parser already has a limit (`kMaxDiacAfterSymbol = 2`) on how many diacritics can follow a base character, the combining marks from `Mark_Enclosing` (e.g., U+20DD COMBINING ENCLOSING CIRCLE, U+20DE COMBINING ENCLOSING SQUARE, U+20DF COMBINING ENCLOSING DIAMOND, U+20E0 COMBINING ENCLOSING CIRCLE BACKSLASH) and `Mark_SpacingCombining` categories were not recognized as diacritics and bypassed this limit entirely.

## Fix

Extend `IsDiacritic()` to also recognize `QChar::Mark_Enclosing` and `QChar::Mark_SpacingCombining` Unicode categories. This ensures the existing per-character combining mark limit applies to ALL types of Unicode combining characters, preventing the stacking abuse while preserving legitimate use (the limit of 2 combining marks is sufficient for all natural scripts).

## Affected file

- `ui/text/text.cpp` (in `desktop-app/lib_ui`)

## Testing

Text like `ы` + U+0489 + U+20DD repeated hundreds of times (`ы...`) should now:
- Display with at most 2 combining marks per base character
- Not cause GPU overload
- Not produce visual corruption
