### PR TITLE
Disable custom shadow painting for SeparatePanel on Wayland.

### DIFF
--- a/ui/widgets/separate_panel.cpp
+++ b/ui/widgets/separate_panel.cpp
@@ -1017,7 +1017,10 @@ void SeparatePanel::validateBorderImage() {
 }
 
 QPixmap SeparatePanel::createBorderImage(QColor color) const {
-	const auto shadowPadding = st::callShadow.extend;
+	const auto drawShadow = !::Platform::IsWayland();
+	const auto shadowPadding = drawShadow
+		? st::callShadow.extend
+		: style::margins(0, 0, 0, 0);
 	const auto cacheSize = st::separatePanelBorderCacheSize;
 	auto cache = QImage(
 		cacheSize * style::DevicePixelRatio(),
@@ -1029,7 +1032,9 @@ QPixmap SeparatePanel::createBorderImage(QColor color) const {
 		auto p = QPainter(&cache);
 		auto inner = QRect(0, 0, cacheSize, cacheSize).marginsRemoved(
 			shadowPadding);
-		Shadow::paint(p, inner, cacheSize, st::callShadow);
+		if (drawShadow) {
+			Shadow::paint(p, inner, cacheSize, st::callShadow);
+		}
 		p.setCompositionMode(QPainter::CompositionMode_Source);
 		p.setBrush(color);
 		p.setPen(Qt::NoPen);
@@ -1348,7 +1353,9 @@ void SeparatePanel::initGeometry(QSize size) {
 	}
 	_useTransparency = Platform::TranslucentWindowsSupported();
 	_padding = _useTransparency
-		? st::callShadow.extend
+		? (::Platform::IsWayland()
+			? style::margins(0, 0, 0, 0)
+			: st::callShadow.extend)
 		: style::margins(
 			st::lineWidth,
 			st::lineWidth,


### PR DESCRIPTION
**Problem**

On Wayland, SeparatePanel renders its own client-side shadow via `Shadow::paint()` and applies `st::callShadow.extend` as padding. However, on Wayland the compositor already provides window shadows. 

**Root Cause**

`createBorderImage()` and `initGeometry()` unconditionally applied `st::callShadow.extend` as shadow padding and drew the shadow, without checking whether the platform already provides compositor-level shadows.

![how_it_was](https://github.com/user-attachments/assets/94d90d06-8840-438d-bafa-adbff9967942)

**Fix**

<img width="1168" height="1252" alt="fixed_state" src="https://github.com/user-attachments/assets/6caee335-38a6-4dcb-8876-51799da7447b" />


**Affected file**

- `ui/widgets/separate_panel.cpp` (in `desktop-app/lib_ui`)

**Testing**

On Wayland SeparatePanel should display with compositor-provided shadow only