### PR TITLE
Fix random heap as pixels noise

### DIFF
--- a/ui/image/image_prepare.cpp
+++ b/ui/image/image_prepare.cpp
@@ -462,7 +462,15 @@ std::array<QImage, 4> PrepareCorners(
 	result.format = reader.format().toLower();
 	result.animated = reader.supportsAnimation()
 		&& (reader.imageCount() > 1);
+	result.image = QImage(size, QImage::Format_ARGB32_Premultiplied);
+	if (result.image.isNull()) {
+		return {};
+	}
+	result.image.fill(Qt::transparent);
 	if (!reader.read(&result.image) || result.image.isNull()) {
+		return {};
+	}
+	if (reader.error() != QImageReader::UnknownError) {
 		return {};
 	}
 	return result;
@@ -1251,9 +1259,7 @@ QImage Prepare(QImage image, int w, int h, const PrepareArgs &args) {
 			image.setDevicePixelRatio(ratio);
 			auto result = QImage(outer, QImage::Format_ARGB32_Premultiplied);
 			result.setDevicePixelRatio(ratio);
-			if (args.options & Images::Option::TransparentBackground) {
-				result.fill(Qt::transparent);
-			}
+			result.fill(Qt::transparent);
 			{
 				QPainter p(&result);
 				if (!(args.options & Images::Option::TransparentBackground)) {


### PR DESCRIPTION
<img width="285" height="419" alt="image" src="https://github.com/user-attachments/assets/11d95102-2968-4db9-8c77-6a9d79fcea14" />

(corrupted video)
<img width="580" height="440" alt="image" src="https://github.com/user-attachments/assets/e1f06790-0f7a-4a6f-b62c-1ea4dd650746" />

(https://t.me/bg/kO4jyq55SFABAAAA0WEpcLfahXk?intensity=55&bg_color=bbbee8-c5c0e3&rotation=223 link in chat links preview)
