### PR TITLE
Fix closing of inline pre markdown blocks.

### DIFF
--- a/ui/widgets/fields/input_field.cpp
+++ b/ui/widgets/fields/input_field.cpp
@@ -551,7 +551,10 @@ public:
 		const auto check = [&](Edge edge) {
 			if (_position > 0) {
 				const auto before = text[_position - 1];
-				if (tag == kTagPre && before != '\n' && before != '\r') {
+				if (edge == Edge::Open
+					&& tag == kTagPre
+					&& before != '\n'
+					&& before != '\r') {
 					return false;
 				}
 				if ((edge == Edge::Open && !isGoodBefore(before))


### PR DESCRIPTION
## Summary

A single-line `` ```code``` `` block is no longer recognised by the markdown parser. Sending such a message produces literal `` ```code``` `` text instead of a `Pre`/`messageEntityPre`-formatted code block. The multi-line form (`` ```\ncode\n``` ``) still works.

This is a regression introduced by 5e3b435ec ("Force a newline before ``` in markdown parsing", 2026‑03‑04). The first affected TDesktop release is **v6.7.0**; the bug is still present on `master` and v6.8.1.

## Reproduction

Steps in any chat input field:

1. Type `` ```text``` `` on a single line — note: no newlines.
2. Press Enter to send.

Expected:
- The bubble renders `text` as a code block (monospace, distinct background).
- Outgoing payload contains `messageEntityPre offset=0 length=4`.

Actual:
- The bubble renders the raw seven characters `` ```text``` ``.
- No `messageEntityPre` is sent.

A simpler programmatic check: in any input field with `setMarkdownReplacesEnabled(true)`, type `` ```text``` `` and inspect `getTextWithAppliedMarkdown()`. On `master` it returns the original text with no markdown tag attached.

## Root cause

The check inside `TagSearchItem::fill()`'s `check` lambda (`ui/widgets/fields/input_field.cpp`, ~line 551):

```cpp
const auto check = [&](Edge edge) {
    if (_position > 0) {
        const auto before = text[_position - 1];
        if (tag == kTagPre && before != '\n' && before != '\r') {
            return false;
        }
        if ((edge == Edge::Open && !isGoodBefore(before))
            || (edge == Edge::Close && isBadBefore(before))) {
            return false;
        }
    }
    ...
};
```

is invoked for both the **opening** match and the **closing** match of `kTagPre`. The newline-before predicate added in 5e3b435ec sits unconditionally inside `if (_position > 0)`, so it applies to both edges.

Walking the parser for `` ```text``` `` (length 10):

1. `MarkdownTagAccumulator::feed("\`\`\`text\`\`\`", 10, "")` runs.
2. **Opening search.** `text.indexOf("\`\`\`", 0) == 0`. The new check is skipped because `_position == 0` makes `if (_position > 0)` false. The opening match is accepted and `kTagPre` is opened at offset `0`.
3. **Closing search.** Offset advances to `4`. `text.indexOf("\`\`\`", 4) == 7`. `_position > 0`, so we evaluate `before = text[6] == 't'`. The new predicate fires: `'t' != '\n' && 't' != '\r'` → `return false`. The match is **rejected** despite being a syntactically valid close.
4. No further `` ``` `` exists, so the search exhausts and the `kTagPre` tag remains open.
5. `MarkdownTagAccumulator::finish()` finalises the unclosed tag with `closed = false`.
6. `getTextWithAppliedMarkdown()` iterates `_lastMarkdownTags` and skips the unclosed tag at the very first guard:
   ```cpp
   if (!tag.closed || tag.adjustedStart < from) {
       continue;
   }
   ```
7. The function returns the original text unchanged. `ConvertTextTagsToEntities` produces no `Pre` entity, and the message is dispatched as plain text.

The intent stated in 5e3b435ec — "force a newline **before** ```" — is naturally about the *opening* tag (preventing `Hello ` `` ```code``` `` from accidentally starting a Pre block in the middle of a line). The closing match never benefited from this rule and was already correctly guarded by `isBadBefore` (`!= '`'`) plus the `goodAfter` separators check.

## Fix

Restrict the newline predicate to `Edge::Open`. The closing match falls back to its pre-regression behaviour.

```diff
 const auto check = [&](Edge edge) {
     if (_position > 0) {
         const auto before = text[_position - 1];
-        if (tag == kTagPre && before != '\n' && before != '\r') {
+        if (edge == Edge::Open
+            && tag == kTagPre
+            && before != '\n'
+            && before != '\r') {
             return false;
         }
         if ((edge == Edge::Open && !isGoodBefore(before))
             || (edge == Edge::Close && isBadBefore(before))) {
             return false;
         }
     }
```

No other call sites or APIs change. `TagStartExpressions`, `MarkdownTagAccumulator`, `getTextWithAppliedMarkdown`, `ConvertTextTagsToEntities`, and the `kInMaskTypesBlock` machinery downstream are untouched.

## Why this is the right fix

Two alternatives were considered and rejected:

1. **Revert 5e3b435ec entirely.** This would re-introduce the original concern that motivated the commit (an opening `` ``` `` matching mid-line). The targeted fix preserves that protection.
2. **Apply the rule symmetrically and add a special case for inline pairs.** Detecting that a close belongs to a same-line opening would require look-back logic in `check`, which currently has no awareness of the partner edge's position. The current architecture stores tag-level state (`_currentTag`, `_currentFreeTag`) but the `check` lambda is per `TagSearchItem` and per fragment, so threading partner-edge data here would be invasive. Restricting the predicate to `Edge::Open` is a single-line change with the same observable effect.

## Behaviour matrix

| Input | Before 5e3b435ec | Current `master` | With this PR |
|---|---|---|---|
| `` ```code``` `` (start of input) | Pre | plain | **Pre** |
| `` ```\ncode\n``` `` | Pre | Pre | Pre |
| `` ```code\n``` `` (close on next line) | Pre | Pre | Pre |
| `` ```cpp\nint x;\n``` `` (with language) | Pre `cpp` | Pre `cpp` | Pre `cpp` |
| `` Hello ```code``` `` (open mid-line) | Pre (unintended) | plain | plain |
| `` Hello\n```code``` `` (open after `\n`, close inline) | Pre | plain *(secondary regression)* | **Pre** |
| `` `code` `` (single backtick / `kTagCode`) | Code | Code | Code |

Row 6 is an additional regression introduced by 5e3b435ec that this PR also resolves: an opening `` ``` `` that does sit at the start of its line (and so passes the new opening-side rule) was nevertheless failing because its inline closing was being rejected.

## Test plan

The lib_ui repository does not currently expose unit tests for the InputField markdown parser, so the verification is manual against a TDesktop build with this lib_ui revision pinned in. All cases tested by typing into a chat compose field and inspecting both the rendered bubble and the `messageEntityPre` payload via the TG Desktop API logs.

- [x] `` ```text``` `` → Pre entity, offset 0, length 4.
- [x] `` ```\ntext\n``` `` → Pre entity (existing newline-trimming logic in `getTextWithAppliedMarkdown` handles the surrounding `\n`).
- [x] `` ```cpp\nint x = 1;\n``` `` → Pre entity, language `cpp`.
- [x] `` Hello ```code``` `` → no Pre entity (opening rejected by the preserved rule).
- [x] `` Hello\n```code``` `` → Pre entity wrapping `code`.
- [x] `` `inline` `` (`kTagCode`) is unaffected.
- [x] `` **bold** ``, `` __italic__ ``, `` ~~strike~~ ``, `` ||spoiler|| `` are unaffected (the predicate is gated on `tag == kTagPre`).
- [x] `getTextWithAppliedMarkdown()` for empty document and single-character documents does not crash (no off-by-one introduced; `_position == 0` short-circuits identically to before).

## Affected releases

- Introduced in lib_ui commit 5e3b435ec, 2026‑03‑04.
- First TDesktop release pinning the regression: **v6.7.0** (2026‑04‑04).
- Still present in v6.8.1 (2026‑05‑08, current latest).
