### PR TITLE
feat(accessibility): support SetFocus and Press actions on painted list items

### DIFF
--- a/ui/accessible/ui_accessible_item.cpp
+++ b/ui/accessible/ui_accessible_item.cpp
@@ -127,6 +127,40 @@ QAccessibleInterface *Item::parent() const {
 	return QAccessible::queryAccessibleInterface(_parent.get());
 }
 
+void *Item::interface_cast(QAccessible::InterfaceType type) {
+	if (type == QAccessible::ActionInterface) {
+		return static_cast<QAccessibleActionInterface*>(this);
+	}
+	return nullptr;
+}
+
+QStringList Item::actionNames() const {
+	const auto parent = _parent.get();
+	if (!parent || _index < 0) {
+		return {};
+	}
+	// Only advertise focusing when the row claims to be focusable,
+	// matching the state() we report to the screen reader.
+	if (parent->accessibilityChildState(_index).focusable) {
+		return { QAccessibleActionInterface::setFocusAction() };
+	}
+	return {};
+}
+
+void Item::doAction(const QString &actionName) {
+	const auto parent = _parent.get();
+	if (!parent || _index < 0) {
+		return;
+	}
+	if (actionName == QAccessibleActionInterface::setFocusAction()) {
+		parent->accessibilityChildSetFocus(_index);
+	}
+}
+
+QStringList Item::keyBindingsForAction(const QString &actionName) const {
+	return {};
+}
+
 SubItem::SubItem(not_null<RpWidget*> parent, int row, int column)
 : _parent(parent)
 , _row(row)

--- a/ui/accessible/ui_accessible_item.cpp
+++ b/ui/accessible/ui_accessible_item.cpp
@@ -12,16 +12,31 @@ namespace Ui::Accessible {
 
 Item::Item(not_null<RpWidget*> parent, int index)
 : _parent(parent)
-, _index(index) {
+, _index(index)
+, _identity(parent->accessibilityChildIdentity(index)) {
+}
+
+int Item::currentIndex() const {
+	const auto parent = _parent.get();
+	if (!parent) {
+		return -1;
+	}
+	return _identity
+		? parent->accessibilityChildIndexByIdentity(_identity)
+		: _index;
 }
 
 bool Item::isValid() const {
 	const auto parent = _parent.get();
-	if (_index < 0 || !parent || !parent->isVisible()) {
+	if (!parent || !parent->isVisible()) {
+		return false;
+	}
+	const auto index = currentIndex();
+	if (index < 0) {
 		return false;
 	}
 	const auto count = parent->accessibilityChildCount();
-	return count < 0 || _index < count;
+	return count < 0 || index < count;
 }
 
 QObject *Item::object() const {
@@ -43,23 +58,25 @@ QAccessible::Role Item::role() const {
 
 QAccessible::State Item::state() const {
 	const auto parent = _parent.get();
-	return (parent && _index >= 0)
-		? parent->accessibilityChildState(_index)
+	const auto index = parent ? currentIndex() : -1;
+	return (index >= 0)
+		? parent->accessibilityChildState(index)
 		: QAccessible::State();
 }
 
 QString Item::text(QAccessible::Text t) const {
 	const auto parent = _parent.get();
-	if (_index < 0 || !parent) {
+	const auto index = parent ? currentIndex() : -1;
+	if (index < 0) {
 		return {};
 	}
 	switch (t) {
 	case QAccessible::Name:
-		return parent->accessibilityChildName(_index);
+		return parent->accessibilityChildName(index);
 	case QAccessible::Description:
-		return parent->accessibilityChildDescription(_index);
+		return parent->accessibilityChildDescription(index);
 	case QAccessible::Value:
-		return parent->accessibilityChildValue(_index);
+		return parent->accessibilityChildValue(index);
 	}
 	return QString();
 }
@@ -69,10 +86,11 @@ void Item::setText(QAccessible::Text t, const QString &text) {
 
 QRect Item::rect() const {
 	const auto parent = _parent.get();
-	if (_index < 0 || !parent) {
+	const auto index = parent ? currentIndex() : -1;
+	if (index < 0) {
 		return {};
 	}
-	const auto local = parent->accessibilityChildRect(_index);
+	const auto local = parent->accessibilityChildRect(index);
 	if (local.isEmpty()) {
 		return {};
 	}
@@ -81,16 +99,18 @@ QRect Item::rect() const {
 
 int Item::childCount() const {
 	const auto parent = _parent.get();
-	if (_index < 0 || !parent) {
+	const auto index = parent ? currentIndex() : -1;
+	if (index < 0) {
 		return 0;
 	}
-	return parent->accessibilityChildColumnCount(_index);
+	return parent->accessibilityChildColumnCount(index);
 }
 
 QAccessibleInterface *Item::child(int index) const {
 	const auto parent = _parent.get();
-	const auto columns = parent
-		? parent->accessibilityChildColumnCount(_index)
+	const auto current = parent ? currentIndex() : -1;
+	const auto columns = (current >= 0)
+		? parent->accessibilityChildColumnCount(current)
 		: 0;
 	if (index < 0 || index >= columns) {
 		return nullptr;
@@ -99,20 +119,26 @@ QAccessibleInterface *Item::child(int index) const {
 		_subitems = std::make_unique<SubItems>();
 	}
 	auto &ids = _subitems->list;
+	// Drop cached sub-items when the row moved, so they describe the row this
+	// provider currently maps to rather than its construction-time index.
+	if (_subitemsIndex != current) {
+		ids.clear();
+		_subitemsIndex = current;
+	}
 	if (int(ids.size()) != columns) {
 		ids.resize(columns); // UniqueId handles deregistration.
 	}
 	if (!ids[index]) {
 		ids[index] = UniqueId(
 			QAccessible::registerAccessibleInterface(
-				new SubItem(parent, _index, index)));
+				new SubItem(parent, current, index)));
 	}
 	return ids[index].get();
 }
 
 int Item::indexOfChild(const QAccessibleInterface *child) const {
 	if (const auto subItem = dynamic_cast<const SubItem*>(child)) {
-		if (subItem->row() == _index) {
+		if (subItem->row() == currentIndex()) {
 			return subItem->column();
 		}
 	}
@@ -129,31 +155,59 @@ QAccessibleInterface *Item::parent() const {
 
 void *Item::interface_cast(QAccessible::InterfaceType type) {
 	if (type == QAccessible::ActionInterface) {
-		return static_cast<QAccessibleActionInterface*>(this);
+		// Expose the action interface only when the owner opted in for this
+		// child. Otherwise the Windows UIA bridge would advertise Invoke /
+		// SetFocus / SelectionItem and report success while doing nothing.
+		const auto parent = _parent.get();
+		const auto index = parent ? currentIndex() : -1;
+		if (index >= 0
+			&& parent->accessibilityChildSupportsActions(index)) {
+			return static_cast<QAccessibleActionInterface*>(this);
+		}
 	}
 	return nullptr;
 }
 
 QStringList Item::actionNames() const {
 	const auto parent = _parent.get();
-	if (!parent || _index < 0) {
+	const auto index = parent ? currentIndex() : -1;
+	if (index < 0 || !parent->accessibilityChildSupportsActions(index)) {
 		return {};
 	}
+	const auto childState = parent->accessibilityChildState(index);
+	// Pressing invokes the item's default action (e.g. open the chat).
+	auto names = QStringList{ QAccessibleActionInterface::pressAction() };
 	// Only advertise focusing when the row claims to be focusable,
 	// matching the state() we report to the screen reader.
-	if (parent->accessibilityChildState(_index).focusable) {
-		return { QAccessibleActionInterface::setFocusAction() };
+	if (childState.focusable) {
+		names.append(QAccessibleActionInterface::setFocusAction());
 	}
-	return {};
+	// Selecting a list item maps to making it the current row. Advertise it
+	// (and, more importantly, handle it in doAction) so SelectionItem.Select
+	// does not silently report success: Qt routes ListItem selection through
+	// toggleAction() on the Qt 5 Windows bridge.
+	if (childState.selectable) {
+		names.append(QAccessibleActionInterface::toggleAction());
+	}
+	return names;
 }
 
 void Item::doAction(const QString &actionName) {
 	const auto parent = _parent.get();
-	if (!parent || _index < 0) {
+	if (!parent) {
 		return;
 	}
-	if (actionName == QAccessibleActionInterface::setFocusAction()) {
-		parent->accessibilityChildSetFocus(_index);
+	// Dispatch by stable identity, not index: the owner resolves it to the
+	// current row on the main thread, so a stale action either hits the right
+	// row (if it just moved) or fails safely (if it is gone). We forward the
+	// identity without touching widget state here, because the Windows UIA
+	// bridge invokes actions on a background thread.
+	const auto identity = _identity;
+	if (actionName == QAccessibleActionInterface::setFocusAction()
+		|| actionName == QAccessibleActionInterface::toggleAction()) {
+		parent->accessibilityChildSetFocus(identity);
+	} else if (actionName == QAccessibleActionInterface::pressAction()) {
+		parent->accessibilityChildActivate(identity);
 	}
 }
 

--- a/ui/accessible/ui_accessible_item.h
+++ b/ui/accessible/ui_accessible_item.h
@@ -85,6 +85,14 @@ public:
 	[[nodiscard]] int index() const {
 		return _index;
 	}
+	[[nodiscard]] quintptr identity() const {
+		return _identity;
+	}
+
+	// The row this provider currently maps to: resolved from the stable
+	// identity when one is set (so the provider follows a reordered row or
+	// becomes invalid when it is gone), otherwise the construction-time index.
+	[[nodiscard]] int currentIndex() const;
 
 	bool isValid() const override;
 	QObject *object() const override;
@@ -116,7 +124,9 @@ public:
 private:
 	base::weak_qptr<RpWidget> _parent;
 	mutable std::unique_ptr<SubItems> _subitems;
+	mutable int _subitemsIndex = -1;
 	int _index = 0;
+	quintptr _identity = 0;
 
 };
 

--- a/ui/accessible/ui_accessible_item.h
+++ b/ui/accessible/ui_accessible_item.h
@@ -76,7 +76,9 @@ struct SubItems {
 	std::vector<UniqueId> list;
 };
 
-class Item final : public QAccessibleInterface {
+class Item final
+	: public QAccessibleInterface
+	, public QAccessibleActionInterface {
 public:
 	Item(not_null<RpWidget*> parent, int index);
 
@@ -101,6 +103,15 @@ public:
 	QAccessibleInterface *childAt(int x, int y) const override;
 
 	QAccessibleInterface *parent() const override;
+
+	// QAccessibleInterface.
+	void *interface_cast(QAccessible::InterfaceType type) override;
+
+	// QAccessibleActionInterface.
+	QStringList actionNames() const override;
+	void doAction(const QString &actionName) override;
+	QStringList keyBindingsForAction(
+		const QString &actionName) const override;
 
 private:
 	base::weak_qptr<RpWidget> _parent;

--- a/ui/accessible/ui_accessible_widget.cpp
+++ b/ui/accessible/ui_accessible_widget.cpp
@@ -167,7 +167,7 @@ QAccessibleInterface* Widget::child(int index) const {
 
 int Widget::indexOfChild(const QAccessibleInterface* child) const {
 	if (const auto item = dynamic_cast<const Ui::Accessible::Item*>(child)) {
-		return item->index();
+		return item->currentIndex();
 	}
 	if (child) {
 		const auto widgets = rp()->accessibilityChildWidgets();

--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -455,6 +455,9 @@ void RpWidget::accessibilityChildFocused(int index) {
 	QAccessible::updateAccessibility(&event);
 }
 
+void RpWidget::accessibilityChildSetFocus(int index) {
+}
+
 QString RpWidget::accessibilityName() {
 	return QWidget::accessibleName();
 }

--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -455,7 +455,22 @@ void RpWidget::accessibilityChildFocused(int index) {
 	QAccessible::updateAccessibility(&event);
 }
 
-void RpWidget::accessibilityChildSetFocus(int index) {
+bool RpWidget::accessibilityChildSupportsActions(int index) const {
+	return false;
+}
+
+quintptr RpWidget::accessibilityChildIdentity(int index) const {
+	return 0;
+}
+
+int RpWidget::accessibilityChildIndexByIdentity(quintptr identity) const {
+	return -1;
+}
+
+void RpWidget::accessibilityChildSetFocus(quintptr identity) {
+}
+
+void RpWidget::accessibilityChildActivate(quintptr identity) {
 }
 
 QString RpWidget::accessibilityName() {
@@ -533,6 +548,17 @@ QAccessibleInterface *RpWidget::accessibilityChildInterface(
 	auto &ids = items.list;
 	if (int(ids.size()) < count) {
 		ids.resize(count);
+	}
+	// Drop a cached item whose row was reordered or replaced, so its stable
+	// identity (and the data the screen reader reads) stays in sync with the
+	// row currently at this index. Destroying the stale item also invalidates
+	// any provider the assistive technology may still be holding for it.
+	if (ids[index]) {
+		const auto identity = accessibilityChildIdentity(index);
+		const auto cached = dynamic_cast<Accessible::Item*>(ids[index].get());
+		if (cached && cached->identity() != identity) {
+			ids[index] = Accessible::UniqueId();
+		}
 	}
 	if (!ids[index]) {
 		ids[index] = Accessible::UniqueId(

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -451,7 +451,31 @@ public:
 	[[nodiscard]] virtual QString accessibilityChildSubItemName(int row, int column) const;
 	[[nodiscard]] virtual QString accessibilityChildSubItemValue(int row, int column) const;
 	void accessibilityChildFocused(int index);
-	virtual void accessibilityChildSetFocus(int index);
+
+	// Per-child opt-in for the accessibility action interface (SetFocus /
+	// Invoke / SelectionItem.Select). Returns false by default, so painted
+	// lists do not advertise actions they cannot perform. A widget that
+	// returns true must support all three meaningfully, because the Windows
+	// UIA bridge exposes SetFocus and SelectionItem regardless of
+	// actionNames() once an action interface is present.
+	[[nodiscard]] virtual bool accessibilityChildSupportsActions(
+		int index) const;
+
+	// Stable identity of a child, used to keep an action bound to the row the
+	// assistive technology actually referenced even if the model reorders or
+	// replaces the row at that index. Returns 0 ("no stable identity") by
+	// default; a widget opting into actions must provide a non-zero token and
+	// implement accessibilityChildIndexByIdentity().
+	[[nodiscard]] virtual quintptr accessibilityChildIdentity(
+		int index) const;
+	[[nodiscard]] virtual int accessibilityChildIndexByIdentity(
+		quintptr identity) const;
+
+	// Actions are dispatched by stable identity (resolved on the main thread
+	// by the owner) rather than by index, so a queued action never operates
+	// on a replacement row.
+	virtual void accessibilityChildSetFocus(quintptr identity);
+	virtual void accessibilityChildActivate(quintptr identity);
 
 protected:
 	// e - from enterEvent() of child RpWidget

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -451,6 +451,7 @@ public:
 	[[nodiscard]] virtual QString accessibilityChildSubItemName(int row, int column) const;
 	[[nodiscard]] virtual QString accessibilityChildSubItemValue(int row, int column) const;
 	void accessibilityChildFocused(int index);
+	virtual void accessibilityChildSetFocus(int index);
 
 protected:
 	// e - from enterEvent() of child RpWidget


### PR DESCRIPTION
Painted/virtual list items exposed via `Accessible::Item` advertise themselves as focusable, but they provided no `QAccessibleActionInterface` — so a screen reader could neither move focus to such an item (UIA `SetFocus`) nor activate it (UIA `Invoke`).

This makes `Accessible::Item` implement `QAccessibleActionInterface`, but only for children whose owner opts in:

- `RpWidget::accessibilityChildSupportsActions(index)` (default `false`) gates the interface; `interface_cast` returns `nullptr` otherwise, so unrelated painted lists don't advertise no-op Invoke / SetFocus / Select on Windows.
- `actionNames()` advertises `pressAction()`, `setFocusAction()` (when the row is focusable) and `toggleAction()` (when selectable — Qt routes UIA `SelectionItem.Select` through it on the Qt 5 bridge).
- `doAction()` routes press → `accessibilityChildActivate`, focus/toggle → `accessibilityChildSetFocus`.

Actions are dispatched by a **stable identity**, not by index: the owner provides `accessibilityChildIdentity(index)` / `accessibilityChildIndexByIdentity(token)`, and the action virtuals take that token. The owner resolves it to the current row on the main thread, so a reorder or replacement can't make a queued action hit the wrong row. A cached item is also dropped when the row at its index changes identity.

All the new `RpWidget` virtuals default to no-ops / empty, so a widget opts in explicitly (e.g. the chat list).
