### PR TITLE
feat(accessibility): support PageTab role and selected state on buttons

### DIFF
--- a/ui/abstract_button.cpp
+++ b/ui/abstract_button.cpp
@@ -210,9 +210,14 @@ void AbstractButton::setDisabled(bool disabled) {
 	auto was = _state;
 	if (disabled && !(_state & StateFlag::Disabled)) {
 		_state |= StateFlag::Disabled;
+		// Keep the real widget state in sync so QAccessibleWidget reports the
+		// disabled state from QWidget::isEnabled() - no custom accessibility
+		// override needed.
+		setEnabled(false);
 		onStateChanged(was, StateChangeSource::ByUser);
 	} else if (!disabled && (_state & StateFlag::Disabled)) {
 		_state &= ~State(StateFlag::Disabled);
+		setEnabled(true);
 		onStateChanged(was, StateChangeSource::ByUser);
 	}
 }

--- a/ui/abstract_button.h
+++ b/ui/abstract_button.h
@@ -63,9 +63,19 @@ public:
 	void setIsMenuButton(bool value) {
 		_menuButton = value;
 	}
+	void setIsPageTab(bool value) {
+		_pageTab = value;
+	}
+	[[nodiscard]] bool isPageTab() const {
+		return _pageTab;
+	}
 
 	QAccessible::Role accessibilityRole() override {
-		return _menuButton ? QAccessible::ButtonMenu : QAccessible::Button;
+		return _pageTab
+			? QAccessible::PageTab
+			: _menuButton
+			? QAccessible::ButtonMenu
+			: QAccessible::Button;
 	}
 	AccessibilityState accessibilityState() const override;
 	void accessibilityDoAction(const QString &name) override;
@@ -121,6 +131,7 @@ private:
 	bool _acceptBoth : 1 = false;
 	bool _triggerOnPress : 1 = false;
 	bool _menuButton : 1 = false;
+	bool _pageTab : 1 = false;
 
 	Fn<void()> _clickedCallback;
 

--- a/ui/accessible/ui_accessible_widget.cpp
+++ b/ui/accessible/ui_accessible_widget.cpp
@@ -267,6 +267,19 @@ QStringList Widget::actionNames() const {
 }
 
 void Widget::doAction(const QString &actionName) {
+	// On Qt 5 the Windows UIA bridge redirects a container's SetFocus to
+	// focusChild() only for an element exposing a table interface, not for a
+	// PageTabList - so focus would land on the container. Forward SetFocus to
+	// the selected tab's widget directly instead (no extra Qt patch needed).
+	if (actionName == QAccessibleActionInterface::setFocusAction()
+		&& rp()->accessibilityRole() == QAccessible::PageTabList) {
+		if (const auto selected = selectedItem(0)) {
+			if (const auto widget = qobject_cast<QWidget*>(selected->object())) {
+				widget->setFocus(Qt::OtherFocusReason);
+				return;
+			}
+		}
+	}
 	QAccessibleWidget::doAction(actionName);
 	base::Integration::Instance().enterFromEventLoop([&] {
 		rp()->accessibilityDoAction(actionName);

--- a/ui/accessible/ui_accessible_widget.cpp
+++ b/ui/accessible/ui_accessible_widget.cpp
@@ -91,6 +91,10 @@ not_null<RpWidget*> Widget::rp() const {
 // Interface cast.
 
 void *Widget::interface_cast(QAccessible::InterfaceType type) {
+	if (type == QAccessible::SelectionInterface
+		&& rp()->accessibilityRole() == QAccessible::PageTabList) {
+		return static_cast<QAccessibleSelectionInterface*>(this);
+	}
 	return QAccessibleWidget::interface_cast(type);
 }
 
@@ -230,6 +234,57 @@ void Widget::doAction(const QString &actionName) {
 	base::Integration::Instance().enterFromEventLoop([&] {
 		rp()->accessibilityDoAction(actionName);
 	});
+}
+
+// Selection. The selected children are those reporting `selected` (a page tab
+// reports selected = active), so the active tab resolves independently of focus.
+
+int Widget::selectedItemCount() const {
+	return int(selectedItems().size());
+}
+
+QList<QAccessibleInterface*> Widget::selectedItems() const {
+	auto result = QList<QAccessibleInterface*>();
+	const auto count = childCount();
+	for (auto i = 0; i != count; ++i) {
+		if (const auto item = child(i)) {
+			if (item->state().selected) {
+				result.append(item);
+			}
+		}
+	}
+	return result;
+}
+
+QAccessibleInterface *Widget::selectedItem(int selectionIndex) const {
+	// Bounds-safe: an out-of-range index (including negative) yields nullptr.
+	return selectedItems().value(selectionIndex, nullptr);
+}
+
+bool Widget::isSelected(QAccessibleInterface *childItem) const {
+	return childItem && childItem->state().selected;
+}
+
+bool Widget::select(QAccessibleInterface *childItem) {
+	if (childItem) {
+		if (const auto actions = childItem->actionInterface()) {
+			actions->doAction(QAccessibleActionInterface::pressAction());
+			return true;
+		}
+	}
+	return false;
+}
+
+bool Widget::unselect(QAccessibleInterface*) {
+	return false; // A tab control always keeps one current tab.
+}
+
+bool Widget::selectAll() {
+	return false; // Single-selection container.
+}
+
+bool Widget::clear() {
+	return false; // A tab control always keeps one current tab.
 }
 
 } // namespace Ui::Accessible

--- a/ui/accessible/ui_accessible_widget.cpp
+++ b/ui/accessible/ui_accessible_widget.cpp
@@ -138,6 +138,10 @@ int Widget::childCount() const {
 	if (count >= 0) {
 		return count;
 	}
+	const auto widgets = rp()->accessibilityChildWidgets();
+	if (!widgets.empty()) {
+		return int(widgets.size());
+	}
 	return QAccessibleWidget::childCount();
 }
 
@@ -148,12 +152,30 @@ QAccessibleInterface* Widget::child(int index) const {
 	if (const auto customInterface = rp()->accessibilityChildInterface(index)) {
 		return customInterface;
 	}
+	const auto widgets = rp()->accessibilityChildWidgets();
+	if (!widgets.empty()) {
+		return (index < int(widgets.size()))
+			? QAccessible::queryAccessibleInterface(widgets[index].get())
+			: nullptr;
+	}
 	return QAccessibleWidget::child(index);
 }
 
 int Widget::indexOfChild(const QAccessibleInterface* child) const {
 	if (const auto item = dynamic_cast<const Ui::Accessible::Item*>(child)) {
 		return item->index();
+	}
+	if (child) {
+		const auto widgets = rp()->accessibilityChildWidgets();
+		if (!widgets.empty()) {
+			const auto object = child->object();
+			for (auto i = 0; i != int(widgets.size()); ++i) {
+				if (widgets[i].get() == object) {
+					return i;
+				}
+			}
+			return -1;
+		}
 	}
 	return QAccessibleWidget::indexOfChild(child);
 }
@@ -184,6 +206,17 @@ QAccessibleInterface* Widget::focusChild() const {
 	}
 	++ReentrancyDepth;
 	struct Guard { ~Guard() { --ReentrancyDepth; } } guard;
+
+	// A tab control forwards accessible focus to its current (selected) tab, so
+	// focusing the container lands the screen reader on the active tab. Only do
+	// this while the container itself holds focus - if a specific tab has
+	// keyboard focus, fall through so that focused tab is reported instead.
+	if (rp()->accessibilityRole() == QAccessible::PageTabList
+		&& widget()->hasFocus()) {
+		if (const auto selected = selectedItem(0)) {
+			return selected;
+		}
+	}
 
 	// Only handle focus child for widgets with custom accessibility children.
 	// For other widgets (containers, scroll areas), delegate to Qt immediately.

--- a/ui/accessible/ui_accessible_widget.cpp
+++ b/ui/accessible/ui_accessible_widget.cpp
@@ -303,11 +303,18 @@ bool Widget::isSelected(QAccessibleInterface *childItem) const {
 }
 
 bool Widget::select(QAccessibleInterface *childItem) {
-	if (childItem) {
-		if (const auto actions = childItem->actionInterface()) {
-			actions->doAction(QAccessibleActionInterface::pressAction());
-			return true;
-		}
+	// Only report success for an item that belongs to this container and can
+	// actually become selected - otherwise (e.g. a locked tab whose press just
+	// opens an upsell) we must not claim the selection succeeded.
+	if (!childItem
+		|| indexOfChild(childItem) < 0
+		|| childItem->state().disabled
+		|| !childItem->state().selectable) {
+		return false;
+	}
+	if (const auto actions = childItem->actionInterface()) {
+		actions->doAction(QAccessibleActionInterface::pressAction());
+		return true;
 	}
 	return false;
 }

--- a/ui/accessible/ui_accessible_widget.cpp
+++ b/ui/accessible/ui_accessible_widget.cpp
@@ -95,6 +95,10 @@ void *Widget::interface_cast(QAccessible::InterfaceType type) {
 		&& rp()->accessibilityRole() == QAccessible::PageTabList) {
 		return static_cast<QAccessibleSelectionInterface*>(this);
 	}
+	if (type == QAccessible::AttributesInterface
+		&& rp()->accessibilityOrientation().has_value()) {
+		return static_cast<QAccessibleAttributesInterface*>(this);
+	}
 	return QAccessibleWidget::interface_cast(type);
 }
 
@@ -318,6 +322,26 @@ bool Widget::selectAll() {
 
 bool Widget::clear() {
 	return false; // A tab control always keeps one current tab.
+}
+
+// Attributes. Reports the container's orientation (e.g. a vertical tab strip)
+// so UI Automation can describe a horizontal/vertical tab control.
+
+QList<QAccessible::Attribute> Widget::attributeKeys() const {
+	auto result = QList<QAccessible::Attribute>();
+	if (rp()->accessibilityOrientation().has_value()) {
+		result.append(QAccessible::Attribute::Orientation);
+	}
+	return result;
+}
+
+QVariant Widget::attributeValue(QAccessible::Attribute key) const {
+	if (key == QAccessible::Attribute::Orientation) {
+		if (const auto orientation = rp()->accessibilityOrientation()) {
+			return int(*orientation);
+		}
+	}
+	return QVariant();
 }
 
 } // namespace Ui::Accessible

--- a/ui/accessible/ui_accessible_widget.h
+++ b/ui/accessible/ui_accessible_widget.h
@@ -14,7 +14,9 @@ class RpWidget;
 
 namespace Ui::Accessible {
 
-class Widget : public QAccessibleWidget {
+class Widget
+	: public QAccessibleWidget
+	, public QAccessibleSelectionInterface {
 public:
 	explicit Widget(not_null<RpWidget*> widget);
 
@@ -43,6 +45,18 @@ public:
 	// Actions.
 	QStringList actionNames() const override;
 	void doAction(const QString &actionName) override;
+
+	// Selection. Exposed (via interface_cast) only for the PageTabList tab
+	// container, so UI Automation resolves the selected tab from
+	// state().selected - independent of keyboard focus.
+	int selectedItemCount() const override;
+	QList<QAccessibleInterface*> selectedItems() const override;
+	QAccessibleInterface *selectedItem(int selectionIndex) const override;
+	bool isSelected(QAccessibleInterface *childItem) const override;
+	bool select(QAccessibleInterface *childItem) override;
+	bool unselect(QAccessibleInterface *childItem) override;
+	bool selectAll() override;
+	bool clear() override;
 
 };
 

--- a/ui/accessible/ui_accessible_widget.h
+++ b/ui/accessible/ui_accessible_widget.h
@@ -16,7 +16,8 @@ namespace Ui::Accessible {
 
 class Widget
 	: public QAccessibleWidget
-	, public QAccessibleSelectionInterface {
+	, public QAccessibleSelectionInterface
+	, public QAccessibleAttributesInterface {
 public:
 	explicit Widget(not_null<RpWidget*> widget);
 
@@ -57,6 +58,12 @@ public:
 	bool unselect(QAccessibleInterface *childItem) override;
 	bool selectAll() override;
 	bool clear() override;
+
+	// Attributes. Exposed (via interface_cast) only when the widget reports an
+	// accessibilityOrientation(), so UI Automation can announce a horizontal or
+	// vertical tab control.
+	QList<QAccessible::Attribute> attributeKeys() const override;
+	QVariant attributeValue(QAccessible::Attribute key) const override;
 
 };
 

--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -332,6 +332,7 @@ void AccessibilityState::writeTo(QAccessible::State &state) {
 	state.checked = checked ? 1 : 0;
 	state.pressed = pressed ? 1 : 0;
 	state.readOnly = readOnly ? 1 : 0;
+	state.selectable = selectable ? 1 : 0;
 	state.selected = selected ? 1 : 0;
 }
 
@@ -501,6 +502,10 @@ void RpWidget::accessibilityDoAction(const QString &name) {
 
 int RpWidget::accessibilityChildCount() const {
 	return -1;
+}
+
+std::vector<not_null<QWidget*>> RpWidget::accessibilityChildWidgets() const {
+	return {};
 }
 
 RpWidget *RpWidget::accessibilityParent() const {

--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -508,6 +508,10 @@ std::vector<not_null<QWidget*>> RpWidget::accessibilityChildWidgets() const {
 	return {};
 }
 
+std::optional<Qt::Orientation> RpWidget::accessibilityOrientation() const {
+	return std::nullopt;
+}
+
 RpWidget *RpWidget::accessibilityParent() const {
 	return nullptr;
 }

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -422,6 +422,11 @@ public:
 	// use the default QWidget enumeration.
 	[[nodiscard]] virtual std::vector<not_null<QWidget*>> accessibilityChildWidgets() const;
 
+	// Orientation of a tab-control container (PageTabList), exposed to UIA so a
+	// screen reader can announce a horizontal/vertical tab list. nullopt (the
+	// default) means the widget reports no orientation.
+	[[nodiscard]] virtual std::optional<Qt::Orientation> accessibilityOrientation() const;
+
 	[[nodiscard]] virtual RpWidget *accessibilityParent() const;
 	[[nodiscard]] virtual QAccessibleInterface* accessibilityChildInterface(int index) const;
 	[[nodiscard]] virtual QString accessibilityChildName(int index) const;

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -374,6 +374,7 @@ struct AccessibilityState {
 	bool checked : 1 = false;
 	bool pressed : 1 = false;
 	bool readOnly : 1 = false;
+	bool selectable : 1 = false;
 	bool selected : 1 = false;
 
 	void writeTo(QAccessible::State &state);
@@ -415,6 +416,12 @@ public:
 	[[nodiscard]] virtual QStringList accessibilityActionNames();
 	virtual void accessibilityDoAction(const QString &name);
 	[[nodiscard]] virtual int accessibilityChildCount() const;
+
+	// Real child widgets in accessibility (visual) order, when it differs from
+	// the QObject child order (e.g. a reorderable VerticalLayout). Empty means
+	// use the default QWidget enumeration.
+	[[nodiscard]] virtual std::vector<not_null<QWidget*>> accessibilityChildWidgets() const;
+
 	[[nodiscard]] virtual RpWidget *accessibilityParent() const;
 	[[nodiscard]] virtual QAccessibleInterface* accessibilityChildInterface(int index) const;
 	[[nodiscard]] virtual QString accessibilityChildName(int index) const;

--- a/ui/widgets/side_bar_button.cpp
+++ b/ui/widgets/side_bar_button.cpp
@@ -52,7 +52,15 @@ void SideBarButton::setActive(bool active) {
 		return;
 	}
 	_active = active;
+	if (isPageTab()) {
+		accessibilityStateChanged({ .selected = active });
+	}
 	update();
+}
+
+AccessibilityState SideBarButton::accessibilityState() const {
+	// Expose the active page tab as selected (persistent, independent of focus).
+	return { .selected = isPageTab() && _active };
 }
 
 void SideBarButton::setBadge(const QString &badge, bool muted) {

--- a/ui/widgets/side_bar_button.cpp
+++ b/ui/widgets/side_bar_button.cpp
@@ -11,6 +11,7 @@
 #include "styles/style_widgets.h"
 
 #include <QtGui/QtEvents>
+#include <QAccessible>
 
 namespace Ui {
 namespace {
@@ -53,14 +54,27 @@ void SideBarButton::setActive(bool active) {
 	}
 	_active = active;
 	if (isPageTab()) {
-		accessibilityStateChanged({ .selected = active });
+		// Announce selection via a dedicated selection event (the Windows
+		// bridge maps these to UIA_SelectionItem_ElementSelected); a generic
+		// state-change event is ignored for the selected state.
+		auto event = QAccessibleEvent(
+			this,
+			active ? QAccessible::SelectionAdd : QAccessible::SelectionRemove);
+		QAccessible::updateAccessibility(&event);
 	}
 	update();
 }
 
 AccessibilityState SideBarButton::accessibilityState() const {
-	// Expose the active page tab as selected (persistent, independent of focus).
-	return { .selected = isPageTab() && _active };
+	// Merge the base state so non-tab buttons keep reporting `pressed`. A page
+	// tab is selectable and exposes the active one as selected - persistently,
+	// independent of keyboard focus.
+	auto state = RippleButton::accessibilityState();
+	if (isPageTab()) {
+		state.selectable = true;
+		state.selected = _active;
+	}
+	return state;
 }
 
 void SideBarButton::setBadge(const QString &badge, bool muted) {

--- a/ui/widgets/side_bar_button.h
+++ b/ui/widgets/side_bar_button.h
@@ -44,6 +44,7 @@ public:
 			? u"%1 (%2)"_q.arg(_text.toString(), _badge.toString())
 			: _text.toString();
 	}
+	AccessibilityState accessibilityState() const override;
 
 private:
 	void paintEvent(QPaintEvent *e) override;

--- a/ui/wrap/vertical_layout.cpp
+++ b/ui/wrap/vertical_layout.cpp
@@ -8,6 +8,8 @@
 
 #include "ui/ui_utility.h"
 
+#include <QAccessible>
+
 namespace Ui {
 
 QMargins VerticalLayout::getMargins() const {
@@ -52,6 +54,19 @@ void VerticalLayout::reorderRows(int oldIndex, int newIndex) {
 
 	base::reorder(_rows, oldIndex, newIndex);
 	resizeToWidth(width());
+
+	// The accessible (visual) child order changed - tell screen readers.
+	auto event = QAccessibleEvent(this, QAccessible::ObjectReorder);
+	QAccessible::updateAccessibility(&event);
+}
+
+std::vector<not_null<QWidget*>> VerticalLayout::accessibilityChildWidgets() const {
+	auto result = std::vector<not_null<QWidget*>>();
+	result.reserve(_rows.size());
+	for (const auto &row : _rows) {
+		result.push_back(row.widget.data());
+	}
+	return result;
 }
 
 int VerticalLayout::resizeGetHeight(int newWidth) {

--- a/ui/wrap/vertical_layout.h
+++ b/ui/wrap/vertical_layout.h
@@ -75,6 +75,7 @@ public:
 	}
 
 	QMargins getMargins() const override;
+	std::vector<not_null<QWidget*>> accessibilityChildWidgets() const override;
 
 	void setVerticalShift(int index, int shift);
 	void reorderRows(int oldIndex, int newIndex);


### PR DESCRIPTION
## Summary
Exposes a custom tab control (Telegram's chat-folders strip) to screen readers by implementing the Qt 6 selection/attributes accessibility interfaces on the accessible container, plus the supporting `PageTab`/`PageTabList` state. Native on Qt 6; on Qt 5.15 it pairs with the qtbase backports in desktop-app/patches#254. Wired up in telegramdesktop/tdesktop#30772.

## What it does

**`Ui::Accessible::Widget`** (the `QAccessibleWidget` wrapper)
- Implements `QAccessibleSelectionInterface` for role `PageTabList`: the **current tab** is the selected item, answered from each child's `state().selected` — persistent and independent of keyboard focus.
- Implements `QAccessibleAttributesInterface`, exposed (via `interface_cast`) only when the widget reports an `accessibilityOrientation()` — returns the `Orientation` attribute so a vertical tab list is announced as vertical.
- Forwards accessible focus from the container to the active tab (`focusChild`).
- Drives `childCount`/`child`/`indexOfChild` from a new `accessibilityChildWidgets()` hook, so UIA sibling navigation follows the **visual** child order.

**`AbstractButton` / `SideBarButton`**
- `setIsPageTab()` / `isPageTab()`; `accessibilityRole()` returns `PageTab`.
- `accessibilityState()` **merges** the base state (keeps `pressed`) and, for a page tab, reports `selectable` + `selected = _active`.
- `setActive()` announces selection with a dedicated **`SelectionAdd`/`SelectionRemove`** event.
- `setDisabled()` keeps `QWidget::setEnabled()` in sync, so a disabled button is reported as disabled from the real widget state (`QAccessibleWidget`) rather than a custom field — this fixes disabled announcement for every button.

**`VerticalLayout`**
- Overrides `accessibilityChildWidgets()` (visual order) and emits `QAccessible::ObjectReorder` from `reorderRows()` — drag-reorder keeps the accessible sibling order in sync.

**`RpWidget` / `AccessibilityState`**
- New reusable hooks: `accessibilityChildWidgets()` and `accessibilityOrientation()` (default unset).
- New `selectable` state bit.

## Why selection is decoupled from focus
Qt's Windows bridge derives both `UIA_HasKeyboardFocus` and (in its default `PageTab` path) `IsSelected` from the same `state().focused` bit. Answering selection from a real `QAccessibleSelectionInterface` (reading `state().selected`) keeps the active tab `SELECTED` persistently while `HasKeyboardFocus` stays honest. On Qt 5.15 the bridge consults the interfaces via desktop-app/patches#254; on Qt 6 it's native.
