### PR TITLE
Let ElasticScroll pass unhandled keys to the parent

### DIFF
--- a/ui/widgets/elastic_scroll.cpp
+++ b/ui/widgets/elastic_scroll.cpp
@@ -1110,6 +1110,10 @@ void ElasticScroll::keyPressEvent(QKeyEvent *e) {
 			? style::ConvertScale(20)
 			: height();
 		tryScrollTo(_state.visibleFrom + (up ? -step : step));
+	} else {
+		// Let keys we don't handle (e.g. typed characters) propagate to
+		// the parent widget instead of being silently accepted here.
+		e->ignore();
 	}
 }
 


### PR DESCRIPTION
`ElasticScroll::keyPressEvent` silently accepted keys it does not handle (e.g. typed characters), so they never propagated to parent widgets.

This makes it `ignore()` unhandled keys instead, allowing parents to react to them — for example, redirecting chat-list typing to the search field for screen-reader users.