### PR TITLE
Recenter boxes after dimension changes

### DIFF
--- a/ui/layers/box_layer_widget.cpp
+++ b/ui/layers/box_layer_widget.cpp
@@ -418,18 +418,20 @@ void BoxLayerWidget::setDimensions(
 			resize(newWidth, countRealHeight());
 			auto newGeometry = geometry();
 			auto parentHeight = parent->height();
+			const auto newLeft = (parent->width() - newGeometry.width()) / 2;
+			auto newTop = newGeometry.top();
 			const auto bottomMargin = st().margin.bottom();
 			if (newGeometry.top() + newGeometry.height() + bottomMargin > parentHeight
 				|| forceCenterPosition) {
 				const auto top1 = parentHeight - bottomMargin - newGeometry.height();
 				const auto top2 = (parentHeight - newGeometry.height()) / 2;
-				const auto newTop = forceCenterPosition
+				newTop = forceCenterPosition
 					? std::min(top1, top2)
 					: std::max(top1, top2);
-				if (newTop != newGeometry.top()) {
-					move(newGeometry.left(), newTop);
-					resizeEvent(0);
-				}
+			}
+			if (newLeft != newGeometry.left() || newTop != newGeometry.top()) {
+				move(newLeft, newTop);
+				resizeEvent(0);
 			}
 			parent->update(oldGeometry.united(geometry()).marginsAdded(st::boxRoundShadow.extend));
 		} else {


### PR DESCRIPTION
## Summary

Recenter box layers horizontally after their dimensions change while they are centered within the outer layer container.

## Why

Some box content can resize after opening or after a parent/screen geometry change. The existing path already recalculates the vertical position, but keeps the old left coordinate, so a centered box can drift horizontally when its width changes.

## Validation

Built Telegram Desktop Debug with the dependent tdesktop changes:

`docker run --rm -u 1001:1003 -v /home/vitaly/p/tdesktop:/usr/src/tdesktop -e CONFIG=Debug tdesktop:centos_env cmake --build /usr/src/tdesktop/out --config Debug --target Telegram`
