### PR TITLE
Use List/ListItem accessibility role for ordered button strips

### DIFF
--- a/ui/abstract_button.h
+++ b/ui/abstract_button.h
@@ -63,16 +63,16 @@ public:
 	void setIsMenuButton(bool value) {
 		_menuButton = value;
 	}
-	void setIsPageTab(bool value) {
-		_pageTab = value;
+	void setIsListItem(bool value) {
+		_listItem = value;
 	}
-	[[nodiscard]] bool isPageTab() const {
-		return _pageTab;
+	[[nodiscard]] bool isListItem() const {
+		return _listItem;
 	}
 
 	QAccessible::Role accessibilityRole() override {
-		return _pageTab
-			? QAccessible::PageTab
+		return _listItem
+			? QAccessible::ListItem
 			: _menuButton
 			? QAccessible::ButtonMenu
 			: QAccessible::Button;
@@ -131,7 +131,7 @@ private:
 	bool _acceptBoth : 1 = false;
 	bool _triggerOnPress : 1 = false;
 	bool _menuButton : 1 = false;
-	bool _pageTab : 1 = false;
+	bool _listItem : 1 = false;
 
 	Fn<void()> _clickedCallback;
 

--- a/ui/accessible/ui_accessible_widget.cpp
+++ b/ui/accessible/ui_accessible_widget.cpp
@@ -92,7 +92,7 @@ not_null<RpWidget*> Widget::rp() const {
 
 void *Widget::interface_cast(QAccessible::InterfaceType type) {
 	if (type == QAccessible::SelectionInterface
-		&& rp()->accessibilityRole() == QAccessible::PageTabList) {
+		&& rp()->accessibilitySelectionList()) {
 		return static_cast<QAccessibleSelectionInterface*>(this);
 	}
 	if (type == QAccessible::AttributesInterface
@@ -211,11 +211,13 @@ QAccessibleInterface* Widget::focusChild() const {
 	++ReentrancyDepth;
 	struct Guard { ~Guard() { --ReentrancyDepth; } } guard;
 
-	// A tab control forwards accessible focus to its current (selected) tab, so
-	// focusing the container lands the screen reader on the active tab. Only do
-	// this while the container itself holds focus - if a specific tab has
-	// keyboard focus, fall through so that focused tab is reported instead.
-	if (rp()->accessibilityRole() == QAccessible::PageTabList
+	// A selection list forwards accessible focus to its current (selected) item,
+	// so focusing the container lands the screen reader on a navigable item
+	// rather than the inert container. Only while the container itself holds
+	// focus - if a specific item has keyboard focus, fall through so it is
+	// reported. Opt-in, so plain lists (e.g. message history, which tracks a
+	// separate focused item) are not affected.
+	if (rp()->accessibilitySelectionList()
 		&& widget()->hasFocus()) {
 		if (const auto selected = selectedItem(0)) {
 			return selected;
@@ -269,10 +271,11 @@ QStringList Widget::actionNames() const {
 void Widget::doAction(const QString &actionName) {
 	// On Qt 5 the Windows UIA bridge redirects a container's SetFocus to
 	// focusChild() only for an element exposing a table interface, not for a
-	// PageTabList - so focus would land on the container. Forward SetFocus to
-	// the selected tab's widget directly instead (no extra Qt patch needed).
+	// List - so focus would land on the inert container. Forward SetFocus to
+	// the selected item's widget directly instead (no extra Qt patch needed).
+	// Opt-in, so only a selection list (the folder strip) is affected.
 	if (actionName == QAccessibleActionInterface::setFocusAction()
-		&& rp()->accessibilityRole() == QAccessible::PageTabList) {
+		&& rp()->accessibilitySelectionList()) {
 		if (const auto selected = selectedItem(0)) {
 			if (const auto widget = qobject_cast<QWidget*>(selected->object())) {
 				widget->setFocus(Qt::OtherFocusReason);
@@ -286,10 +289,10 @@ void Widget::doAction(const QString &actionName) {
 	});
 }
 
-// Selection. Only actual page-tab children participate: a selection item is a
-// child with the PageTab role, and the selected one reports selected = active,
-// so the active tab resolves independently of focus. Plain buttons among the
-// children (e.g. a locked, premium-gated folder) are deliberately excluded.
+// Selection. A selection item is a child with the ListItem role reporting
+// selected = active; the selected one resolves independently of focus. Plain
+// buttons among the children are excluded, and a locked folder reports
+// selectable = false, so it is never claimed as a successful selection.
 
 int Widget::selectedItemCount() const {
 	return int(selectedItems().size());
@@ -301,7 +304,7 @@ QList<QAccessibleInterface*> Widget::selectedItems() const {
 	for (auto i = 0; i != count; ++i) {
 		const auto item = child(i);
 		if (item
-			&& item->role() == QAccessible::PageTab
+			&& item->role() == QAccessible::ListItem
 			&& item->state().selected) {
 			result.append(item);
 		}
@@ -317,17 +320,18 @@ QAccessibleInterface *Widget::selectedItem(int selectionIndex) const {
 bool Widget::isSelected(QAccessibleInterface *childItem) const {
 	return childItem
 		&& indexOfChild(childItem) >= 0
-		&& childItem->role() == QAccessible::PageTab
+		&& childItem->role() == QAccessible::ListItem
 		&& childItem->state().selected;
 }
 
 bool Widget::select(QAccessibleInterface *childItem) {
-	// Only report success for a page tab that belongs to this container and can
+	// Only report success for a list item that belongs to this container and can
 	// actually become selected - otherwise (e.g. a locked folder whose press
-	// just opens an upsell) we must not claim the selection succeeded.
+	// just opens an upsell) we must not claim the selection succeeded. A list
+	// item only implements pressAction, so invoke that rather than toggleAction.
 	if (!childItem
 		|| indexOfChild(childItem) < 0
-		|| childItem->role() != QAccessible::PageTab
+		|| childItem->role() != QAccessible::ListItem
 		|| childItem->state().disabled
 		|| !childItem->state().selectable) {
 		return false;
@@ -340,7 +344,7 @@ bool Widget::select(QAccessibleInterface *childItem) {
 }
 
 bool Widget::unselect(QAccessibleInterface*) {
-	return false; // A tab control always keeps one current tab.
+	return false; // A single-selection list always keeps one current item.
 }
 
 bool Widget::selectAll() {
@@ -348,11 +352,11 @@ bool Widget::selectAll() {
 }
 
 bool Widget::clear() {
-	return false; // A tab control always keeps one current tab.
+	return false; // A single-selection list always keeps one current item.
 }
 
-// Attributes. Reports the container's orientation (e.g. a vertical tab strip)
-// so UI Automation can describe a horizontal/vertical tab control.
+// Attributes. Reports the container's orientation (e.g. a vertical list) so UI
+// Automation can describe a horizontal/vertical orientation.
 
 QList<QAccessible::Attribute> Widget::attributeKeys() const {
 	auto result = QList<QAccessible::Attribute>();

--- a/ui/accessible/ui_accessible_widget.h
+++ b/ui/accessible/ui_accessible_widget.h
@@ -47,9 +47,10 @@ public:
 	QStringList actionNames() const override;
 	void doAction(const QString &actionName) override;
 
-	// Selection. Exposed (via interface_cast) only for the PageTabList tab
-	// container, so UI Automation resolves the selected tab from
-	// state().selected - independent of keyboard focus.
+	// Selection. Exposed (via interface_cast) only for a List container, so UI
+	// Automation drives SelectionItem.Select() through pressAction() (a list
+	// item only implements pressAction, not toggleAction) and resolves the
+	// selected item from state().selected.
 	int selectedItemCount() const override;
 	QList<QAccessibleInterface*> selectedItems() const override;
 	QAccessibleInterface *selectedItem(int selectionIndex) const override;
@@ -61,7 +62,7 @@ public:
 
 	// Attributes. Exposed (via interface_cast) only when the widget reports an
 	// accessibilityOrientation(), so UI Automation can announce a horizontal or
-	// vertical tab control.
+	// vertical orientation.
 	QList<QAccessible::Attribute> attributeKeys() const override;
 	QVariant attributeValue(QAccessible::Attribute key) const override;
 

--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -512,6 +512,10 @@ std::optional<Qt::Orientation> RpWidget::accessibilityOrientation() const {
 	return std::nullopt;
 }
 
+bool RpWidget::accessibilitySelectionList() const {
+	return false;
+}
+
 RpWidget *RpWidget::accessibilityParent() const {
 	return nullptr;
 }

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -422,10 +422,17 @@ public:
 	// use the default QWidget enumeration.
 	[[nodiscard]] virtual std::vector<not_null<QWidget*>> accessibilityChildWidgets() const;
 
-	// Orientation of a tab-control container (PageTabList), exposed to UIA so a
-	// screen reader can announce a horizontal/vertical tab list. nullopt (the
+	// Orientation of an ordered container (e.g. a list), exposed to UIA so a
+	// screen reader can announce a horizontal/vertical arrangement. nullopt (the
 	// default) means the widget reports no orientation.
 	[[nodiscard]] virtual std::optional<Qt::Orientation> accessibilityOrientation() const;
+
+	// Opt-in for a single-selection list whose accessible focus tracks its
+	// selected item: the accessible wrapper exposes QAccessibleSelectionInterface
+	// and forwards container SetFocus/focusChild to the selected child. Default
+	// false - a plain list (e.g. message history, which keeps focus and selection
+	// separate) must not get this behaviour just from reporting the List role.
+	[[nodiscard]] virtual bool accessibilitySelectionList() const;
 
 	[[nodiscard]] virtual RpWidget *accessibilityParent() const;
 	[[nodiscard]] virtual QAccessibleInterface* accessibilityChildInterface(int index) const;

--- a/ui/widgets/side_bar_button.cpp
+++ b/ui/widgets/side_bar_button.cpp
@@ -53,7 +53,7 @@ void SideBarButton::setActive(bool active) {
 		return;
 	}
 	_active = active;
-	if (isPageTab()) {
+	if (isListItem()) {
 		// Announce selection via a dedicated selection event (the Windows
 		// bridge maps these to UIA_SelectionItem_ElementSelected); a generic
 		// state-change event is ignored for the selected state.
@@ -66,12 +66,13 @@ void SideBarButton::setActive(bool active) {
 }
 
 AccessibilityState SideBarButton::accessibilityState() const {
-	// Merge the base state so non-tab buttons keep reporting `pressed`. A page
-	// tab is selectable and exposes the active one as selected - persistently,
-	// independent of keyboard focus.
+	// Merge the base state so plain buttons keep reporting `pressed`. A list
+	// item exposes the active one as selected - persistently, independent of
+	// keyboard focus. A locked (premium) folder stays a focusable, invokable
+	// list item but can never become current, so it isn't selectable.
 	auto state = RippleButton::accessibilityState();
-	if (isPageTab()) {
-		state.selectable = true;
+	if (isListItem()) {
+		state.selectable = !_lock.locked;
 		state.selected = _active;
 	}
 	return state;


### PR DESCRIPTION
## Summary
Switches the chat-folders strip accessibility model from a tab control to a **single-selection list**, which matches NVDA's native list behaviour better.

- Rename `AbstractButton`'s page-tab flag to list-item (`setIsListItem` / `isListItem`): a flagged button reports the **`ListItem`** role instead of `PageTab` — mirroring how the menu-button flag maps to `ButtonMenu`.
- Add an explicit opt-in, **`RpWidget::accessibilitySelectionList()`** (default `false`), for a single-selection list whose accessible focus tracks its selected item. When set, `Ui::Accessible::Widget` exposes `QAccessibleSelectionInterface` and forwards container `SetFocus` / `focusChild` to the selected child — keyed on the opt-in, **not** on the `List` role. So plain lists (e.g. message history, which keeps focus and selection separate) are unaffected and don't advertise a single-selection interface whose `clear()`/`unselect()`/`selectAll()` always fail (incl. AT-SPI on Linux).
- `select()` invokes `pressAction()` — a list item only implements `pressAction`, not the `toggleAction()` Qt's default `ListItem` path would call — and rejects items that aren't selectable, so a locked folder is never claimed as a successful selection. A locked folder reports `selectable = false`.

The attributes (orientation) interface is kept. Paired with the tdesktop change that gives the folders container the `List` role and opts in.
