### PR TITLE
Fix possible null _data crash in Animations::Simple

### DIFF
--- a/ui/effects/animations.h
+++ b/ui/effects/animations.h
@@ -450,9 +450,12 @@ inline void Simple::stop() {
 }
 
 inline bool Simple::animating() const {
-	if (!_data) {
+	// Snapshot the mutable _data: it can be reset re-entrantly between the
+	// null check and the dereference below.
+	const auto data = _data.get();
+	if (!data) {
 		return false;
-	} else if (!_data->animation.animating()) {
+	} else if (!data->animation.animating()) {
 		_data = nullptr;
 		return false;
 	}
@@ -461,8 +464,11 @@ inline bool Simple::animating() const {
 
 TG_FORCE_INLINE float64 Simple::value(float64 final) const {
 	if (animating()) {
-		Assert(!std::isnan(_data->value));
-		return _data->value;
+		// _data may have been reset re-entrantly inside animating().
+		if (const auto data = _data.get()) {
+			Assert(!std::isnan(data->value));
+			return data->value;
+		}
 	}
 	Assert(!std::isnan(final));
 	return final;


### PR DESCRIPTION
`Simple::value()` / `animating()` can dereference a null `_data` and crash (EXC_BAD_ACCESS at 0x0) if the animation gets reset while it's being evaluated.

`_data` is a `mutable unique_ptr` and `animating()` touches it more than once:

```cpp
inline bool Simple::animating() const {
    if (!_data) {
        return false;
    } else if (!_data->animation.animating()) { // _data dereferenced again
        _data = nullptr;
        return false;
    }
    return true;
}
```

`Basic::animating()` is force-inlined (`return _started >= 0;`), so `!_data->animation.animating()` is just a load through `_data`. As `_data` is mutable the compiler reloads it, and if something resets `_data` between the null check and that load (e.g. the owner gets destroyed from an animation tick callback), the load goes through null. `value()` has the same issue with `_data->value`.

Fix: take `_data` into a local once and use that, falling back to `final` when it's gone.

```cpp
inline bool Simple::animating() const {
    const auto data = _data.get();
    if (!data) {
        return false;
    } else if (!data->animation.animating()) {
        _data = nullptr;
        return false;
    }
    return true;
}

TG_FORCE_INLINE float64 Simple::value(float64 final) const {
    if (animating()) {
        if (const auto data = _data.get()) {
            Assert(!std::isnan(data->value));
            return data->value;
        }
    }
    Assert(!std::isnan(final));
    return final;
}
```

Normal path is unchanged, a torn-down animation just returns the final value instead of crashing.

I ran into this with the appearing message text animation, where a tick callback removed the component that owns the `Simple` and freed `_data` mid-call. The call-site fix for that is telegramdesktop/tdesktop#30894, but guarding `Simple` here keeps it safe for any caller.
