### PR TITLE
Initialize ScrollerStopper's mouse position into current position

### DIFF
--- a/ui/widgets/scroll_area.cpp
+++ b/ui/widgets/scroll_area.cpp
@@ -101,7 +101,8 @@ void SetupScrollerPhysics(not_null<QScroller*> scroller, bool ownsOvershoot) {
 	scroller->setScrollerProperties(props);
 }
 
-ScrollerStopper::ScrollerStopper() {
+ScrollerStopper::ScrollerStopper()
+: _mousePos(QCursor::pos()) {
 	qApp->installEventFilter(this);
 }
 


### PR DESCRIPTION
This ensures first scroll isn't stopped