### PR TITLE
Add multi-select fields to AccessibilityState

### DIFF
--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -330,6 +330,8 @@ auto RpWidgetWrap::eventStreams() const -> EventStreams& {
 void AccessibilityState::writeTo(QAccessible::State &state) {
 	state.checkable = checkable ? 1 : 0;
 	state.checked = checked ? 1 : 0;
+	state.extSelectable = extSelectable ? 1 : 0;
+	state.multiSelectable = multiSelectable ? 1 : 0;
 	state.pressed = pressed ? 1 : 0;
 	state.readOnly = readOnly ? 1 : 0;
 	state.selectable = selectable ? 1 : 0;

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -372,6 +372,8 @@ private:
 struct AccessibilityState {
 	bool checkable : 1 = false;
 	bool checked : 1 = false;
+	bool extSelectable : 1 = false;
+	bool multiSelectable : 1 = false;
 	bool pressed : 1 = false;
 	bool readOnly : 1 = false;
 	bool selectable : 1 = false;


### PR DESCRIPTION
﻿Adds `extSelectable` and `multiSelectable` to `AccessibilityState`, forwarded into `QAccessible::State` by `writeTo`.

On Windows the UIA selection pattern derives its answers from these bits: `CanSelectMultiple` comes from `multiSelectable`, and `IsSelectionRequired` is computed as `anySelected && !multiSelectable && !extSelectable`. A list exposing multi-selection currently answers `CanSelectMultiple` = false and, once anything is selected, `IsSelectionRequired` = true - both wrong. Verified with NVDA property queries before/after.

Used by telegramdesktop/tdesktop#30958 (message history lists).
