### PR TITLE
Mac overscroll

### DIFF
--- a/ui/widgets/elastic_scroll.cpp
+++ b/ui/widgets/elastic_scroll.cpp
@@ -66,6 +66,25 @@ constexpr auto kTouchOverscrollMultiplier = 2;
 constexpr auto kLogA = 16.;
 constexpr auto kLogB = 10.;
 
+#ifdef Q_OS_MAC
+// Rubber-band physics matching WebKit / Chromium
+// (blink::ElasticOverscrollControllerExponential), which in turn
+// replicate the native macOS feel: linear stretch = accumulated
+// overscroll / stiffness while dragging, and a critically damped
+// spring x(t) = (x0 + v0 * amplitude * t) * e^(-stiffness * t / period)
+// on release, seeded with the tracked scroll velocity.
+constexpr auto kRubberBandStiffness = 20.;
+constexpr auto kRubberBandAmplitude = 0.31;
+constexpr auto kRubberBandPeriod = 1.6;
+constexpr auto kRubberBandMaxReturnDuration = crl::time(1000);
+constexpr auto kVelocityZeroingTimeout = crl::time(100);
+constexpr auto kMinimumOverscrollBeforeStretch = 10;
+
+// Real macOS trackpad flings top out well below this, so anything
+// higher is an artifact of the per-event-pair velocity estimation.
+constexpr auto kMaxTrackedVelocity = 6000.;
+#endif // Q_OS_MAC
+
 [[nodiscard]] float64 RawFrom(float64 value) {
 	const auto scale = style::Scale() / 100.;
 	value /= scale;
@@ -506,6 +525,12 @@ void ElasticScroll::overscrollReturn() {
 		return;
 	}
 	_movement = Movement::Returning;
+#ifdef Q_OS_MAC
+	if (overscrollSpringSide(_overscroll)) {
+		overscrollSpringStart();
+		return;
+	}
+#endif // Q_OS_MAC
 	_overscrollReturnAnimation.start(
 		[=] { applyAccumulatedScroll(); },
 		0.,
@@ -513,6 +538,106 @@ void ElasticScroll::overscrollReturn() {
 		kOverscrollReturnDuration,
 		anim::sineInOut);
 }
+
+#ifdef Q_OS_MAC
+bool ElasticScroll::overscrollSpringSide(int side) const {
+	const auto type = (side < 0) ? _overscrollTypeFrom : _overscrollTypeTill;
+	return !side ? false : (type == OverscrollType::Real);
+}
+
+void ElasticScroll::trackWheelVelocity(
+		Qt::ScrollPhase phase,
+		int delta,
+		crl::time timestamp) {
+	// Elapsed time is measured between the events' own timestamps: when
+	// the main thread stalls, queued momentum events arrive back-to-back
+	// and processing-time deltas of 1-2ms would inflate the velocity by
+	// an order of magnitude, launching the release bounce way too far.
+	const auto eventTime = timestamp ? timestamp : crl::now();
+	const auto momentum = (phase == Qt::ScrollMomentum);
+	if (phase != Qt::ScrollUpdate && !momentum) {
+		if (phase == Qt::ScrollBegin) {
+			_wheelVelocity = 0.;
+			_wheelVelocityTime = 0;
+			_lastWheelEventTime = eventTime;
+			_pendingOverscrollDelta = 0;
+		}
+		_lastWheelPhaseMomentum = false;
+		return;
+	}
+	// The gap between the fingers lifting and the first momentum event
+	// has no defined duration, so if it is too long to measure velocity
+	// from, keep the velocity tracked from the finger-driven updates
+	// instead of zeroing it: a fling may deliver ScrollBegin followed
+	// directly by momentum events, making that first event the only
+	// velocity sample there is.
+	const auto elapsed = _lastWheelEventTime
+		? (eventTime - _lastWheelEventTime)
+		: crl::time(0);
+	if (elapsed > 0 && elapsed < kVelocityZeroingTimeout) {
+		const auto limit = kMaxTrackedVelocity * style::Scale() / 100.;
+		_wheelVelocity = std::clamp(delta * 1000. / elapsed, -limit, limit);
+		_wheelVelocityTime = crl::now();
+	} else if (!momentum || _lastWheelPhaseMomentum) {
+		_wheelVelocity = 0.;
+		_wheelVelocityTime = crl::now();
+	}
+	_lastWheelEventTime = eventTime;
+	_lastWheelPhaseMomentum = momentum;
+}
+
+void ElasticScroll::overscrollSpringStart() {
+	_springSide = (_overscroll < 0) ? -1 : 1;
+	_springTarget = currentOverscrollDefault();
+	_springX0 = _overscroll - _springTarget;
+	_springV0 = (_wheelVelocityTime
+		&& (crl::now() - _wheelVelocityTime <= kVelocityZeroingTimeout))
+		? _wheelVelocity
+		: 0.;
+	const auto push = _springV0 * kRubberBandAmplitude;
+	const auto decay = kRubberBandStiffness / kRubberBandPeriod;
+	_springPeakTime = ((push != 0.) && ((push > 0.) == (_springX0 > 0.)))
+		? std::max(0., (1. / decay) - (_springX0 / push))
+		: 0.;
+	_overscrollReturnAnimation.start(
+		[=] { overscrollSpringUpdate(); },
+		0.,
+		1.,
+		kRubberBandMaxReturnDuration);
+}
+
+void ElasticScroll::overscrollSpringUpdate() {
+	const auto progress = _overscrollReturnAnimation.value(1.);
+	const auto time = progress * kRubberBandMaxReturnDuration / 1000.;
+	const auto decay = kRubberBandStiffness / kRubberBandPeriod;
+	const auto value = (_springX0 + (_springV0 * kRubberBandAmplitude * time))
+		* std::exp(-decay * time);
+	const auto rounded = int(base::SafeRound(value));
+	const auto crossed = (value == 0.)
+		|| ((value > 0.) != (_springX0 > 0.));
+	if (!_overscrollReturning
+		|| !_springSide
+		|| crossed
+		|| !_overscrollReturnAnimation.animating()
+		|| (!rounded && time >= _springPeakTime)) {
+		overscrollSpringFinish();
+		return;
+	}
+	applyOverscroll(_springTarget + rounded);
+}
+
+void ElasticScroll::overscrollSpringFinish() {
+	_overscrollReturnAnimation.stop();
+	_overscrollReturning = false;
+	_springSide = 0;
+	_overscrollAccumulated = currentOverscrollDefaultAccumulated();
+	const auto weak = base::make_weak(this);
+	applyOverscroll(_springTarget);
+	if (weak) {
+		_movement = Movement::None;
+	}
+}
+#endif // Q_OS_MAC
 
 auto ElasticScroll::computeAccumulatedParts() const ->AccumulatedParts {
 	const auto baseAccumulated = currentOverscrollDefaultAccumulated();
@@ -528,13 +653,27 @@ auto ElasticScroll::computeAccumulatedParts() const ->AccumulatedParts {
 
 void ElasticScroll::overscrollReturnCancel() {
 	_movement = Movement::Progress;
-	if (_overscrollReturning) {
-		const auto parts = computeAccumulatedParts();
-		_overscrollAccumulated = parts.base + parts.relative;
+	if (!_overscrollReturning) {
+		return;
+	}
+#ifdef Q_OS_MAC
+	if (_springSide) {
 		_overscrollReturnAnimation.stop();
 		_overscrollReturning = false;
+		_springSide = 0;
+		_overscrollAccumulated = currentOverscrollDefaultAccumulated()
+			+ overscrollToAccumulated(
+				_overscroll,
+				_overscroll - currentOverscrollDefault());
 		applyAccumulatedScroll();
+		return;
 	}
+#endif // Q_OS_MAC
+	const auto parts = computeAccumulatedParts();
+	_overscrollAccumulated = parts.base + parts.relative;
+	_overscrollReturnAnimation.stop();
+	_overscrollReturning = false;
+	applyAccumulatedScroll();
 }
 
 int ElasticScroll::currentOverscrollDefault() const {
@@ -572,6 +711,9 @@ bool ElasticScroll::overscrollFinish() {
 	_overscrollReturning = false;
 	_overscrollAccumulated = currentOverscrollDefaultAccumulated();
 	_movement = Movement::None;
+#ifdef Q_OS_MAC
+	_springSide = 0;
+#endif // Q_OS_MAC
 	return true;
 }
 
@@ -881,7 +1023,12 @@ bool ElasticScroll::handleWheelEvent(not_null<QWheelEvent*> e, bool touch) {
 		}
 		return true;
 	}
-	return handleScrollEvent(phase, delta, ignore, touch);
+	return handleScrollEvent(
+		phase,
+		delta,
+		ignore,
+		touch,
+		crl::time(e->timestamp()));
 }
 
 bool ElasticScroll::requestBottomContent(int delta) {
@@ -909,12 +1056,28 @@ bool ElasticScroll::handleScrollEvent(
 		Qt::ScrollPhase phase,
 		int delta,
 		bool ignore,
-		bool touch) {
+		bool touch,
+		crl::time timestamp) {
 	const auto momentum = (phase == Qt::ScrollMomentum)
 		|| (phase == Qt::ScrollEnd);
+#ifdef Q_OS_MAC
+	trackWheelVelocity(phase, delta, timestamp);
+#endif // Q_OS_MAC
 	if (_ignoreMomentumFromOverscroll) {
 		if (!momentum) {
 			_ignoreMomentumFromOverscroll = 0;
+#ifdef Q_OS_MAC
+		} else if (_springSide) {
+			if (!base::OppositeSigns(_springSide, delta)) {
+				return true;
+			}
+			// Opposite-direction input during the bounce is a new
+			// gesture whose begin was lost to the momentum-phase
+			// race (Qt may deliver it as a bare momentum stream),
+			// so interrupt the spring like a real begin would.
+			_ignoreMomentumFromOverscroll = 0;
+			overscrollReturnCancel();
+#endif // Q_OS_MAC
 		} else if (!_overscrollReturnAnimation.animating()
 			&& !base::OppositeSigns(_ignoreMomentumFromOverscroll, delta)) {
 			return true;
@@ -922,13 +1085,40 @@ bool ElasticScroll::handleScrollEvent(
 	}
 	if (!momentum) {
 		overscrollReturnCancel();
-	} else if (_overscroll != currentOverscrollDefault()
-		&& !_overscrollReturnAnimation.animating()) {
-		overscrollReturn();
-	} else if (!_overscrollReturnAnimation.animating()) {
-		_movement = (phase == Qt::ScrollEnd)
-			? Movement::None
-			: Movement::Momentum;
+	}
+#ifdef Q_OS_MAC
+	// Chromium's ReconcileStretchAndScroll: scrolling away from the
+	// stretch consumes it 1:1 instead of unwinding through the force
+	// mapping, otherwise a canceled bounce glues the view to the edge
+	// for (stiffness * stretch) of input travel. Runs before the
+	// momentum return branch so that a leaked momentum-phased gesture
+	// unwinds the stretch instead of restarting the spring first.
+	if (delta
+		&& _overscroll != currentOverscrollDefault()
+		&& !_overscrollReturnAnimation.animating()
+		&& overscrollSpringSide(_overscroll)) {
+		const auto base = currentOverscrollDefault();
+		const auto stretch = _overscroll - base;
+		if (base::OppositeSigns(stretch, delta)) {
+			const auto unwound = (stretch < 0)
+				? std::min(stretch + delta, 0)
+				: std::max(stretch + delta, 0);
+			delta -= unwound - stretch;
+			_overscrollAccumulated = currentOverscrollDefaultAccumulated()
+				+ overscrollToAccumulated(_overscroll, unwound);
+			applyOverscroll(base + unwound);
+		}
+	}
+#endif // Q_OS_MAC
+	if (momentum) {
+		if (_overscroll != currentOverscrollDefault()
+			&& !_overscrollReturnAnimation.animating()) {
+			overscrollReturn();
+		} else if (!_overscrollReturnAnimation.animating()) {
+			_movement = (phase == Qt::ScrollEnd)
+				? Movement::None
+				: Movement::Momentum;
+		}
 	}
 	if (!_overscroll) {
 		const auto normalTo = willScrollTo(_state.visibleFrom + delta);
@@ -955,6 +1145,22 @@ bool ElasticScroll::handleScrollEvent(
 	if (touch) {
 		delta *= kTouchOverscrollMultiplier;
 	}
+#ifdef Q_OS_MAC
+	if (!_overscrollAccumulated && overscrollSpringSide(delta)) {
+		if (base::OppositeSigns(_pendingOverscrollDelta, delta)) {
+			_pendingOverscrollDelta = 0;
+		}
+		_pendingOverscrollDelta += delta;
+		const auto minimum = style::ConvertScale(
+			kMinimumOverscrollBeforeStretch);
+		if (std::abs(_pendingOverscrollDelta) < minimum) {
+			return true;
+		}
+		delta = base::take(_pendingOverscrollDelta);
+	} else {
+		_pendingOverscrollDelta = 0;
+	}
+#endif // Q_OS_MAC
 	const auto accumulated = _overscrollAccumulated + delta;
 	const auto type = (accumulated < 0)
 		? _overscrollTypeFrom
@@ -972,6 +1178,14 @@ bool ElasticScroll::handleScrollEvent(
 		_overscrollAccumulated = accumulated;
 	}
 	applyAccumulatedScroll();
+#ifdef Q_OS_MAC
+	if (momentum
+		&& !_overscrollReturnAnimation.animating()
+		&& _overscroll != currentOverscrollDefault()
+		&& overscrollSpringSide(_overscroll)) {
+		overscrollReturn();
+	}
+#endif // Q_OS_MAC
 	return true;
 }
 
@@ -984,7 +1198,27 @@ void ElasticScroll::applyAccumulatedScroll() {
 		? _overscrollDefaultTill
 		: 0;
 	applyOverscroll(baseOverscroll
-		+ OverscrollFromAccumulated(parts.relative));
+		+ overscrollFromAccumulated(_overscrollAccumulated, parts.relative));
+}
+
+int ElasticScroll::overscrollFromAccumulated(
+		int side,
+		int accumulated) const {
+#ifdef Q_OS_MAC
+	if (overscrollSpringSide(side)) {
+		return int(base::SafeRound(accumulated / kRubberBandStiffness));
+	}
+#endif // Q_OS_MAC
+	return OverscrollFromAccumulated(accumulated);
+}
+
+int ElasticScroll::overscrollToAccumulated(int side, int overscroll) const {
+#ifdef Q_OS_MAC
+	if (overscrollSpringSide(side)) {
+		return int(base::SafeRound(overscroll * kRubberBandStiffness));
+	}
+#endif // Q_OS_MAC
+	return OverscrollToAccumulated(overscroll);
 }
 
 bool ElasticScroll::eventFilter(QObject *obj, QEvent *e) {
@@ -1516,6 +1750,10 @@ void ElasticScroll::setOverscrollTypes(
 		switch (_overscrollTypeFrom) {
 		case OverscrollType::None:
 			_overscroll = _overscrollAccumulated = 0;
+#ifdef Q_OS_MAC
+			_overscrollReturnAnimation.stop();
+			overscrollFinish();
+#endif // Q_OS_MAC
 			applyScrollTo(0);
 			break;
 		case OverscrollType::Virtual:
@@ -1531,6 +1769,10 @@ void ElasticScroll::setOverscrollTypes(
 		switch (_overscrollTypeTill) {
 		case OverscrollType::None:
 			_overscroll = _overscrollAccumulated = 0;
+#ifdef Q_OS_MAC
+			_overscrollReturnAnimation.stop();
+			overscrollFinish();
+#endif // Q_OS_MAC
 			applyScrollTo(max);
 			break;
 		case OverscrollType::Virtual:
@@ -1571,7 +1813,7 @@ void ElasticScroll::setOverscrollDefaults(int from, int till, bool shift) {
 			? (_overscroll - (shift ? 0 : _overscrollDefaultFrom))
 			: (_overscroll - (shift ? 0 : _overscrollDefaultTill));
 		_overscrollAccumulated = currentOverscrollDefaultAccumulated()
-			+ OverscrollToAccumulated(delta);
+			+ overscrollToAccumulated(_overscroll, delta);
 	}
 	if (movement == Movement::Momentum || movement == Movement::Returning) {
 		if (_overscroll != currentOverscrollDefault()) {

--- a/ui/widgets/elastic_scroll.cpp
+++ b/ui/widgets/elastic_scroll.cpp
@@ -80,6 +80,37 @@ constexpr auto kRubberBandMaxReturnDuration = crl::time(1000);
 constexpr auto kVelocityZeroingTimeout = crl::time(100);
 constexpr auto kMinimumOverscrollBeforeStretch = 10;
 
+// Pull-to-action sides need to follow the finger much closer than the
+// plain bounce: this approximates the initial slope (~0.55) of the
+// native iOS UIScrollView rubber band, which hosts the same pull
+// affordances in Telegram for iOS, stiffened for a trackpad. Past the
+// pull distance the stretch continues with the plain bounce stiffness,
+// so the content stays contained.
+constexpr auto kPullBandStiffness = 2.5;
+
+// The stretch mapping of a pull side is a single curve anchored at
+// zero stretch, soft over the pull distance and stiff beyond it. The
+// overscroll default only positions the resting point on that curve,
+// so collapsing from an expanded default re-traverses the soft range
+// while pulling deeper than the distance stays stiff.
+[[nodiscard]] float64 PullAccumulatedFromOverscroll(
+		float64 value,
+		float64 distance) {
+	return (value <= distance)
+		? value * kPullBandStiffness
+		: distance * kPullBandStiffness
+			+ (value - distance) * kRubberBandStiffness;
+}
+
+[[nodiscard]] float64 PullOverscrollFromAccumulated(
+		float64 value,
+		float64 distance) {
+	const auto softAccumulated = distance * kPullBandStiffness;
+	return (value <= softAccumulated)
+		? value / kPullBandStiffness
+		: distance + (value - softAccumulated) / kRubberBandStiffness;
+}
+
 // Real macOS trackpad flings top out well below this, so anything
 // higher is an artifact of the per-event-pair velocity estimation.
 constexpr auto kMaxTrackedVelocity = 6000.;
@@ -542,7 +573,38 @@ void ElasticScroll::overscrollReturn() {
 #ifdef Q_OS_MAC
 bool ElasticScroll::overscrollSpringSide(int side) const {
 	const auto type = (side < 0) ? _overscrollTypeFrom : _overscrollTypeTill;
-	return !side ? false : (type == OverscrollType::Real);
+	return !side ? false : (type != OverscrollType::None);
+}
+
+bool ElasticScroll::overscrollPullSide(int side) const {
+	// Virtual and pull-flagged sides host pull-to-action controls (the
+	// stories strip in the chat list, the pull to the next channel in
+	// the chat history), which follow the finger with a much softer
+	// stiffness over the pull distance and stretch without a
+	// minimum-delta threshold. They share the linear mapping and
+	// spring return dynamics with the plain bounce sides.
+	if (!side) {
+		return false;
+	}
+	const auto type = (side < 0) ? _overscrollTypeFrom : _overscrollTypeTill;
+	return (type == OverscrollType::Virtual)
+		|| (type == OverscrollType::Real
+			&& ((side < 0) ? _overscrollPullFrom : _overscrollPullTill) > 0);
+}
+
+float64 ElasticScroll::overscrollPullDistance(int side) const {
+	if (!overscrollPullSide(side)) {
+		return 0.;
+	}
+	const auto distance = (side < 0)
+		? _overscrollPullFrom
+		: _overscrollPullTill;
+	return distance ? float64(distance) : 1e9;
+}
+
+bool ElasticScroll::overscrollCollapsing() const {
+	const auto stretch = _overscroll - currentOverscrollDefault();
+	return (stretch != 0) && base::OppositeSigns(stretch, _overscroll);
 }
 
 void ElasticScroll::trackWheelVelocity(
@@ -1111,8 +1173,22 @@ bool ElasticScroll::handleScrollEvent(
 	}
 #endif // Q_OS_MAC
 	if (momentum) {
-		if (_overscroll != currentOverscrollDefault()
-			&& !_overscrollReturnAnimation.animating()) {
+		auto returning = (_overscroll != currentOverscrollDefault())
+			&& !_overscrollReturnAnimation.animating();
+#ifdef Q_OS_MAC
+		// A momentum fling that retracts a pull (the stretch points
+		// back toward the content, which only happens around an
+		// expanded overscroll default) keeps feeding the collapse
+		// instead of bouncing back to the default, otherwise the
+		// return spring outruns the decaying fling between events and
+		// the pull never collapses. ScrollEnd still starts the return.
+		if (returning
+			&& (phase == Qt::ScrollMomentum)
+			&& overscrollCollapsing()) {
+			returning = false;
+		}
+#endif // Q_OS_MAC
+		if (returning) {
 			overscrollReturn();
 		} else if (!_overscrollReturnAnimation.animating()) {
 			_movement = (phase == Qt::ScrollEnd)
@@ -1146,7 +1222,9 @@ bool ElasticScroll::handleScrollEvent(
 		delta *= kTouchOverscrollMultiplier;
 	}
 #ifdef Q_OS_MAC
-	if (!_overscrollAccumulated && overscrollSpringSide(delta)) {
+	if (!_overscrollAccumulated
+		&& overscrollSpringSide(delta)
+		&& !overscrollPullSide(delta)) {
 		if (base::OppositeSigns(_pendingOverscrollDelta, delta)) {
 			_pendingOverscrollDelta = 0;
 		}
@@ -1182,7 +1260,8 @@ bool ElasticScroll::handleScrollEvent(
 	if (momentum
 		&& !_overscrollReturnAnimation.animating()
 		&& _overscroll != currentOverscrollDefault()
-		&& overscrollSpringSide(_overscroll)) {
+		&& overscrollSpringSide(_overscroll)
+		&& !overscrollCollapsing()) {
 		overscrollReturn();
 	}
 #endif // Q_OS_MAC
@@ -1206,7 +1285,19 @@ int ElasticScroll::overscrollFromAccumulated(
 		int accumulated) const {
 #ifdef Q_OS_MAC
 	if (overscrollSpringSide(side)) {
-		return int(base::SafeRound(accumulated / kRubberBandStiffness));
+		const auto sign = (side < 0) ? -1 : 1;
+		const auto distance = overscrollPullDistance(side);
+		const auto base = std::abs(float64((side < 0)
+			? _overscrollDefaultFrom
+			: _overscrollDefaultTill));
+		const auto baseAccumulated = PullAccumulatedFromOverscroll(
+			base,
+			distance);
+		const auto total = baseAccumulated + sign * accumulated;
+		const auto visual = (total < 0)
+			? -PullOverscrollFromAccumulated(-total, distance)
+			: PullOverscrollFromAccumulated(total, distance);
+		return int(base::SafeRound(sign * (visual - base)));
 	}
 #endif // Q_OS_MAC
 	return OverscrollFromAccumulated(accumulated);
@@ -1215,7 +1306,19 @@ int ElasticScroll::overscrollFromAccumulated(
 int ElasticScroll::overscrollToAccumulated(int side, int overscroll) const {
 #ifdef Q_OS_MAC
 	if (overscrollSpringSide(side)) {
-		return int(base::SafeRound(overscroll * kRubberBandStiffness));
+		const auto sign = (side < 0) ? -1 : 1;
+		const auto distance = overscrollPullDistance(side);
+		const auto base = std::abs(float64((side < 0)
+			? _overscrollDefaultFrom
+			: _overscrollDefaultTill));
+		const auto baseAccumulated = PullAccumulatedFromOverscroll(
+			base,
+			distance);
+		const auto visual = base + sign * overscroll;
+		const auto total = (visual < 0)
+			? -PullAccumulatedFromOverscroll(-visual, distance)
+			: PullAccumulatedFromOverscroll(visual, distance);
+		return int(base::SafeRound(sign * (total - baseAccumulated)));
 	}
 #endif // Q_OS_MAC
 	return OverscrollToAccumulated(overscroll);
@@ -1437,7 +1540,11 @@ void ElasticScroll::setState(ScrollState state) {
 	const auto weak = base::make_weak(this);
 	const auto old = _state.visibleFrom;
 	_state = state;
+#ifdef Q_OS_MAC
+	updateBarState();
+#else // Q_OS_MAC
 	_bar->updateState(state);
+#endif // Q_OS_MAC
 	if (weak) {
 		_position = Position{ _state.visibleFrom, _overscroll };
 	}
@@ -1502,7 +1609,28 @@ void ElasticScroll::applyOverscroll(int overscroll) {
 	} else {
 		applyScrollTo(std::clamp(_state.visibleFrom, 0, max));
 	}
+#ifdef Q_OS_MAC
+	updateBarState();
+#endif // Q_OS_MAC
 }
+
+#ifdef Q_OS_MAC
+void ElasticScroll::updateBarState() {
+	// Virtual overscroll never moves the inner widget, so it never
+	// reaches the state the bar squishes its thumb from - fold it in,
+	// making the thumb behave the same as with Real overscroll.
+	auto state = _state;
+	const auto shift = ((_overscroll < 0
+		&& _overscrollTypeFrom == OverscrollType::Virtual)
+		|| (_overscroll > 0
+			&& _overscrollTypeTill == OverscrollType::Virtual))
+		? _overscroll
+		: 0;
+	state.visibleFrom += shift;
+	state.visibleTill += shift;
+	_bar->updateState(state);
+}
+#endif // Q_OS_MAC
 
 int ElasticScroll::willScrollTo(int position) const {
 	return std::clamp(
@@ -1783,6 +1911,22 @@ void ElasticScroll::setOverscrollTypes(
 			break;
 		}
 	}
+}
+
+void ElasticScroll::setOverscrollPullDistances(int from, int till) {
+	if (_overscrollPullFrom == from && _overscrollPullTill == till) {
+		return;
+	}
+	_overscrollPullFrom = from;
+	_overscrollPullTill = till;
+#ifdef Q_OS_MAC
+	if (_overscroll) {
+		_overscrollAccumulated = currentOverscrollDefaultAccumulated()
+			+ overscrollToAccumulated(
+				_overscroll,
+				_overscroll - currentOverscrollDefault());
+	}
+#endif // Q_OS_MAC
 }
 
 void ElasticScroll::setOverscrollDefaults(int from, int till, bool shift) {

--- a/ui/widgets/elastic_scroll.h
+++ b/ui/widgets/elastic_scroll.h
@@ -252,7 +252,8 @@ private:
 		Qt::ScrollPhase phase,
 		int delta,
 		bool ignore = false,
-		bool touch = false);
+		bool touch = false,
+		crl::time timestamp = 0);
 	bool requestBottomContent(int delta);
 	void handleTouchEvent(QTouchEvent *e);
 
@@ -282,11 +283,26 @@ private:
 	[[nodiscard]] AccumulatedParts computeAccumulatedParts() const;
 	[[nodiscard]] int currentOverscrollDefault() const;
 	[[nodiscard]] int currentOverscrollDefaultAccumulated() const;
+	[[nodiscard]] int overscrollFromAccumulated(
+		int side,
+		int accumulated) const;
+	[[nodiscard]] int overscrollToAccumulated(int side, int overscroll) const;
 	void overscrollReturn();
 	void overscrollReturnCancel();
 	void overscrollCheckReturnFinish();
 	bool overscrollFinish();
 	void applyAccumulatedScroll();
+
+#ifdef Q_OS_MAC
+	[[nodiscard]] bool overscrollSpringSide(int side) const;
+	void trackWheelVelocity(
+		Qt::ScrollPhase phase,
+		int delta,
+		crl::time timestamp);
+	void overscrollSpringStart();
+	void overscrollSpringUpdate();
+	void overscrollSpringFinish();
+#endif // Q_OS_MAC
 
 	const style::ScrollArea &_st;
 	std::unique_ptr<ElasticScrollBar> _bar;
@@ -342,6 +358,19 @@ private:
 	Ui::Animations::Simple _overscrollReturnAnimation;
 	rpl::variable<Position> _position;
 	rpl::variable<Movement> _movement;
+
+#ifdef Q_OS_MAC
+	float64 _wheelVelocity = 0.;
+	crl::time _wheelVelocityTime = 0;
+	crl::time _lastWheelEventTime = 0;
+	bool _lastWheelPhaseMomentum = false;
+	int _pendingOverscrollDelta = 0;
+	int _springSide = 0;
+	int _springTarget = 0;
+	float64 _springX0 = 0.;
+	float64 _springV0 = 0.;
+	float64 _springPeakTime = 0.;
+#endif // Q_OS_MAC
 
 	object_ptr<QWidget> _widget = { nullptr };
 

--- a/ui/widgets/elastic_scroll.h
+++ b/ui/widgets/elastic_scroll.h
@@ -211,6 +211,19 @@ public:
 	// the same way an edge with OverscrollType::None does.
 	void setOverscrollEdges(Fn<bool()> allowTop, Fn<bool()> allowBottom);
 
+	// Marks a Real edge as hosting a pull-to-action control (like the
+	// pull to the next channel in the chat history) reachable within
+	// the given distance of visual stretch, 0 - a plain bounce edge.
+	// On macOS pull edges stretch with a much softer linear stiffness
+	// while the stretch is within that distance and without the
+	// minimum-delta threshold, so the affordance follows the finger
+	// closely from the first pixel; past the distance the stiff bounce
+	// mapping takes over, in both directions - an edge resting at an
+	// expanded overscroll default collapses through the soft range
+	// again. Virtual edges are pull edges implicitly, 0 meaning an
+	// uncapped soft range for them. No-op on other platforms.
+	void setOverscrollPullDistances(int from, int till);
+
 	// Called synchronously when a user scroll gesture (wheel, trackpad,
 	// touch or Down/PageDown key) pushes past the bottom edge, before
 	// any overscroll accumulates. The callback may synchronously append
@@ -295,12 +308,16 @@ private:
 
 #ifdef Q_OS_MAC
 	[[nodiscard]] bool overscrollSpringSide(int side) const;
+	[[nodiscard]] bool overscrollPullSide(int side) const;
+	[[nodiscard]] float64 overscrollPullDistance(int side) const;
+	[[nodiscard]] bool overscrollCollapsing() const;
 	void trackWheelVelocity(
 		Qt::ScrollPhase phase,
 		int delta,
 		crl::time timestamp);
 	void overscrollSpringStart();
 	void overscrollSpringUpdate();
+	void updateBarState();
 	void overscrollSpringFinish();
 #endif // Q_OS_MAC
 
@@ -351,6 +368,8 @@ private:
 	int _overscrollDefaultTill = 0;
 	OverscrollType _overscrollTypeFrom = OverscrollType::Real;
 	OverscrollType _overscrollTypeTill = OverscrollType::Real;
+	int _overscrollPullFrom = 0;
+	int _overscrollPullTill = 0;
 	Fn<bool()> _overscrollAllowFrom;
 	Fn<bool()> _overscrollAllowTill;
 	Fn<bool()> _bottomContentRequest;


### PR DESCRIPTION
> **full disclosure**: i wrote exactly zero lines of code myself, but i reviewed and tested the changes thoroughly (i think (maybe))

ok so overscroll behavior currently implemented in ElasticScroll feels very bad and i asked fable to port the chromium(blink) macos overscroll implementation over here. 

that alone already improved things a lot, but then we also reworked the pull-action stuff (pull-to-next-channel in history and pull-to-stories in chat list), making them feel a lot nicer and more responsive - instead of the log curve it was using.

currently all changes are gated behind `Q_OS_MACOS` (because i dont have any win/linux device to test them), but most of them *should* be portable and work on other platforms with little to no changes. (however kinetic scrolling on both linux and windows needs extra care i believe)

**note:** the changes in the `lib_ui` are just the "core" and require some slight changes in the actual consumers of the main app - see https://github.com/telegramdesktop/tdesktop/pull/30990

before/after (videos dont really do justice, it should be compared side-by-side with an actual trackpad, but i tried my best):

https://github.com/user-attachments/assets/c89f03c3-ea60-4555-898b-444e9e4de180

https://github.com/user-attachments/assets/ec27cfe3-ebb7-4355-801d-e9339e15f0fa

https://github.com/user-attachments/assets/bff25e46-fced-494f-b08a-861484528a30

https://github.com/user-attachments/assets/c1c536ce-3720-4f9f-aea0-f6aeb5469c44

https://github.com/user-attachments/assets/e8e7a18f-f5a2-4447-9730-4883316b5826

https://github.com/user-attachments/assets/daa44912-566b-456c-a3b2-993e4574b78b
