### PR TITLE
Fix stale link activation from checkboxes

### DIFF
--- a/ui/widgets/checkbox.cpp
+++ b/ui/widgets/checkbox.cpp
@@ -800,6 +800,11 @@ void Checkbox::paintEvent(QPaintEvent *e) {
 
 void Checkbox::mousePressEvent(QMouseEvent *e) {
 	RippleButton::mousePressEvent(e);
+	const auto state = getTextState(e->pos());
+	if (state.link != ClickHandler::getActive()) {
+		ClickHandler::setActive(state.link, this);
+		update();
+	}
 	ClickHandler::pressed();
 }
 


### PR DESCRIPTION
Fixes telegramdesktop/tdesktop#30982.

When a checkbox dialog opens over a link without mouse movement, the old link can remain the active ClickHandler. The checkbox then presses and activates that stale handler on release.

This refreshes the handler from the current checkbox position before recording the press.

Tested by building the lib_ui target in the TDesktop 7.0.1 macOS arm64 Release configuration.