### PR TITLE
Fix overscroll bounce reset on programmatic scrolls and resizes.

### DIFF
--- a/ui/widgets/elastic_scroll.cpp
+++ b/ui/widgets/elastic_scroll.cpp
@@ -1358,7 +1358,10 @@ bool ElasticScroll::eventFilter(QObject *obj, QEvent *e) {
 			return true;
 		} else if (e->type() == QEvent::Resize) {
 			const auto weak = base::make_weak(this);
-			updateState();
+			reanchorOverscroll();
+			if (weak) {
+				updateState();
+			}
 			if (weak) {
 				_innerResizes.fire({});
 			}
@@ -1635,6 +1638,25 @@ void ElasticScroll::applyOverscroll(int overscroll) {
 	updateBarState();
 }
 
+// The scroll value an active Real overscroll is pinned to, from fresh sizes
+std::optional<int> ElasticScroll::lookupOverscrollPinnedEdge() const {
+	if (_overscroll < 0 && _overscrollTypeFrom == OverscrollType::Real) {
+		return 0;
+	} else if (_overscroll > 0 && _overscrollTypeTill == OverscrollType::Real) {
+		return (_vertical ? scrollHeight() : scrollWidth()) - (_vertical ? height() : width());
+	}
+	return std::nullopt;
+}
+
+void ElasticScroll::reanchorOverscroll() {
+	// Keep the widget past the (possibly moved) edge after a resize, or
+	// setState() would read the stale position as a scroll away from the
+	// edge and cancel the bounce.
+	if (const auto edge = lookupOverscrollPinnedEdge()) {
+		applyScrollTo(*edge + _overscroll, false);
+	}
+}
+
 void ElasticScroll::updateBarState() {
 	// Virtual overscroll never moves the inner widget, so it never
 	// reaches the state the bar squishes its thumb from - fold it in,
@@ -1721,6 +1743,7 @@ void ElasticScroll::resizeEvent(QResizeEvent *e) {
 			std::max(0, height() - _barTopInset - _barBottomInset))
 		: QRect(0, height() - _st.width, width(), _st.width));
 	_geometryChanged.fire({});
+	reanchorOverscroll();
 	updateState();
 }
 
@@ -1841,6 +1864,10 @@ void ElasticScroll::scrollTo(int toFrom, int toTill) {
 		if (scTo == curFrom) return;
 	} else {
 		scTo = toFrom;
+	}
+	// Scrolling to the pinned edge value to keep the overscroll displacement
+	if (const auto edge = lookupOverscrollPinnedEdge(); edge == scTo) {
+		scTo += _overscroll;
 	}
 	applyScrollTo(scTo);
 	if (_scroller) {

--- a/ui/widgets/elastic_scroll.h
+++ b/ui/widgets/elastic_scroll.h
@@ -276,6 +276,8 @@ private:
 	void tryScrollTo(int position, bool synthMouseMove = true);
 	void applyScrollTo(int position, bool synthMouseMove = true);
 	void applyOverscroll(int overscroll);
+	[[nodiscard]] std::optional<int> lookupOverscrollPinnedEdge() const;
+	void reanchorOverscroll();
 
 	void doSetOwnedWidget(object_ptr<QWidget> widget);
 	object_ptr<QWidget> doTakeWidget();


### PR DESCRIPTION
this happens in history view in a few cases, notably:
- when more messages are loaded
- when i start typing in a chat that has a "bot commands" button - it disappears and resets the scroll

also needs some changes in the main repo - https://github.com/telegramdesktop/tdesktop/pull/31006

before/after:

https://github.com/user-attachments/assets/93383381-d2c3-4c38-8219-ac1638bb6003


https://github.com/user-attachments/assets/78b00cf1-e17b-487d-87dc-3e87a24e7a13


----

improtantly, this is **not** a regression from my previous pr (macos-style elastic), it existed with the old log curve too, just was less noticeable bc it settled quicker