### PR TITLE
Replace QScroller with custom KineticScroller.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,8 @@ PRIVATE
     ui/widgets/menu/menu_toggle.h
     ui/widgets/elastic_scroll.cpp
     ui/widgets/elastic_scroll.h
+    ui/widgets/kinetic_scroller.cpp
+    ui/widgets/kinetic_scroller.h
     ui/widgets/pill_tabs.cpp
     ui/widgets/pill_tabs.h
     ui/widgets/popup_menu.cpp
@@ -335,6 +337,12 @@ PRIVATE
     emoji_suggestions/emoji_suggestions.h
     emoji_suggestions/emoji_suggestions_helper.h
 )
+
+if (QT_VERSION_MAJOR LESS 6)
+    remove_target_sources(lib_ui ${src_loc}
+        ui/widgets/kinetic_scroller.cpp
+    )
+endif()
 
 if (DESKTOP_APP_USE_PACKAGED_FONTS)
     target_compile_definitions(lib_ui PRIVATE LIB_UI_USE_PACKAGED_FONTS)

--- a/ui/ui_utility.cpp
+++ b/ui/ui_utility.cpp
@@ -278,7 +278,8 @@ QPointF ScrollDeltaF(not_null<QWheelEvent*> e, bool touch) {
 	if (!e->pixelDelta().isNull()) {
 #endif // Qt < 6.2.0
 		return convert(e->pixelDelta())
-			* ((::Platform::IsWayland() && !touch)
+			* ((::Platform::IsWayland()
+				&& e->source() != Qt::MouseEventSynthesizedByApplication)
 				? kMagicScrollMultiplier
 				: 1.);
 	}

--- a/ui/ui_utility.cpp
+++ b/ui/ui_utility.cpp
@@ -21,7 +21,6 @@ namespace Ui {
 namespace {
 
 constexpr auto kDefaultWheelScrollLines = 3;
-constexpr auto kMagicScrollMultiplier = 2.5;
 
 class WidgetCreator : public QWidget {
 public:

--- a/ui/ui_utility.h
+++ b/ui/ui_utility.h
@@ -24,6 +24,7 @@ class object_ptr;
 namespace Ui {
 
 inline constexpr auto kPixelToAngleDelta = 2;
+inline constexpr auto kMagicScrollMultiplier = 2.5;
 
 template <typename Widget, typename ...Args>
 inline base::unique_qptr<Widget> CreateObject(Args &&...args) {

--- a/ui/widgets/elastic_scroll.cpp
+++ b/ui/widgets/elastic_scroll.cpp
@@ -8,13 +8,11 @@
 
 #include "ui/painter.h"
 #include "ui/ui_utility.h"
-#include "base/options.h"
 #include "base/qt/qt_common_adapters.h"
 #include "styles/style_widgets.h"
 
 #include <QtGui/QWindow>
 #include <QtCore/QtMath>
-#include <QtWidgets/QScroller>
 #include <QtWidgets/QApplication>
 
 namespace Ui {
@@ -425,36 +423,6 @@ ElasticScroll::ElasticScroll(
 	) | rpl::on_next([=](int from) {
 		tryScrollTo(from, false);
 	}, _bar->lifetime());
-
-	static const auto &OptionQScroller = base::options::lookup<bool>(
-		kOptionQScroller);
-
-	rpl::single(
-		rpl::empty
-	) | rpl::then(
-		OptionQScroller.changes()
-	) | rpl::on_next([=] {
-		if (OptionQScroller.value()) {
-			_scroller = QScroller::scroller(this);
-			SetupScrollerPhysics(_scroller);
-		} else if (_scroller) {
-			QObject deleter;
-			_scroller->setParent(&deleter);
-		}
-
-		if (!_scroller) {
-			return;
-		}
-
-		connect(
-			_scroller,
-			&QScroller::stateChanged,
-			[=](QScroller::State state) {
-				if (state == QScroller::Scrolling) {
-					ScrollerStopper::Instance().activate(_scroller);
-				}
-			});
-	}, lifetime());
 }
 
 ElasticScroll::~ElasticScroll() {
@@ -634,15 +602,6 @@ void ElasticScroll::overscrollSpringStart(int side) {
 		0.,
 		1.,
 		kRubberBandMaxReturnDuration);
-}
-
-void ElasticScroll::overscrollBounce(int side, float64 velocity) {
-	_overscrollReturning = true;
-	_ignoreMomentumFromOverscroll = side;
-	_movement = Movement::Returning;
-	_wheelVelocity = velocity;
-	_wheelVelocityTime = crl::now();
-	overscrollSpringStart(side);
 }
 
 void ElasticScroll::overscrollSpringUpdate() {
@@ -864,85 +823,6 @@ bool ElasticScroll::eventHook(QEvent *e) {
 		}
 		return true;
 	}
-	switch (e->type()) {
-	case QEvent::ScrollPrepare: {
-		QScrollPrepareEvent *se = static_cast<QScrollPrepareEvent *>(e);
-		se->setViewportSize(QSizeF(size()));
-		se->setContentPosRange(QRectF(
-			0,
-			0,
-			_vertical ? 0 : _state.fullSize - width(),
-			_vertical ? _state.fullSize - height() : 0));
-		se->setContentPos(QPointF(
-			_vertical ? 0 : _state.visibleFrom,
-			_vertical ? _state.visibleFrom : 0));
-		se->accept();
-		return true;
-	}
-	case QEvent::Scroll: {
-		QScrollEvent *se = static_cast<QScrollEvent *>(e);
-		const auto state = _scroller->state();
-		const auto phase = state == QScroller::Pressed
-			? Qt::ScrollBegin
-			: state == QScroller::Dragging
-			? Qt::ScrollUpdate
-			: state == QScroller::Scrolling
-			? Qt::ScrollMomentum
-			: Qt::ScrollEnd;
-		const auto pixels
-			= (se->contentPos() + se->overshootDistance()).toPoint();
-		const auto delta
-			= -(_state.visibleFrom - (_vertical ? pixels.y() : pixels.x()));
-		// Capture the fling velocity before this event is tracked: at the
-		// boundary QScroller clamps the delta, so the sample it produces
-		// underestimates the speed the fling actually hit the edge with.
-		const auto velocity = (_wheelVelocityTime
-			&& (crl::now() - _wheelVelocityTime <= kVelocityZeroingTimeout))
-			? _wheelVelocity
-			: 0.;
-		const auto weak = base::make_weak(this);
-		const auto result = handleScrollEvent(phase, delta);
-		if (!weak) {
-			return true;
-		}
-		if (phase == Qt::ScrollMomentum
-			&& velocity != 0.
-			&& _scroller
-			&& _scroller->state() == QScroller::Scrolling
-			&& !_overscrollReturnAnimation.animating()
-			&& _overscroll == currentOverscrollDefault()) {
-			// QScroller's overshoot is disabled, so a fling just stops
-			// dead at the boundary of the range QScroller knows about.
-			const auto side = (velocity < 0.) ? -1 : 1;
-			const auto target = _state.visibleFrom + side;
-			if (willScrollTo(target) != target) {
-				if (side > 0 && requestBottomContent(1)) {
-					// The boundary wasn't a real edge: more content was
-					// appended below, let the fling continue into it.
-					if (weak) {
-						ResendScrollerPrepare(_scroller);
-					}
-					return true;
-				}
-				if (!weak) {
-					return true;
-				}
-				const auto &allowed = (side < 0)
-					? _overscrollAllowFrom
-					: _overscrollAllowTill;
-				if (overscrollSpringSide(side)
-					&& (!allowed || allowed())) {
-					// A real edge: hand the residual velocity over to the
-					// rubber-band spring for the bounce.
-					_scroller->stop();
-					_wheelPos = {};
-					overscrollBounce(side, velocity);
-				}
-			}
-		}
-		return result;
-	}
-	}
 	return RpWidget::eventHook(e);
 }
 
@@ -1064,107 +944,10 @@ bool ElasticScroll::handleWheelEvent(not_null<QWheelEvent*> e, bool touch) {
 			overscrollReturn();
 		}
 		return true;
-	} else if (_scroller && !touch) {
-		// QScroller only provides in-range kinetics (its overshoot is
-		// disabled), so while any overscroll state is active - a stretch,
-		// an accumulated default (like the expanded stories strip), a
-		// pending below-threshold delta or a running bounce - and whenever
-		// the delta pushes past an edge, the raw phased events go through
-		// the elastic overscroll physics directly instead of QScroller.
-		const auto elastic = _overscroll
-			|| _overscrollAccumulated
-			|| _pendingOverscrollDelta
-			|| _overscrollReturning;
-		const auto target = _state.visibleFrom + delta;
-		if (elastic || (delta && willScrollTo(target) != target)) {
-			if (!_wheelPos.isNull()
-				|| _scroller->state() != QScroller::Inactive) {
-				_scroller->stop();
-				_wheelPos = {};
-			}
-			// Pass no timestamp: with QScroller enabled the velocity is
-			// also tracked from its synthetic events, which carry none,
-			// and mixing the events' own clock with the processing-time
-			// one would corrupt the estimation at the transition.
-			return handleScrollEvent(phase, delta, ignore, touch);
-		}
-		switch (phase) {
-		case Qt::ScrollBegin:
-		case Qt::ScrollUpdate: {
-			if (phase == Qt::ScrollBegin
-				&& !pixels.isNull()
-				&& _scroller->state() == QScroller::Scrolling) {
-				// On macOS, when Qt loses the race detecting that a
-				// momentum phase follows the finger lift, the OS momentum
-				// stream leaks through as ScrollBegin + ScrollMomentum.
-				// A real begin (fingers resting on the pad) carries a
-				// zero delta, so a delta-carrying begin while our fling
-				// runs is that leak - pressing would catch and kill the
-				// fling. If this ever swallows a real begin, the next
-				// ScrollUpdate finds _wheelPos null and presses instead.
-				break;
-			}
-			const auto wasNull = _wheelPos.isNull();
-			if (wasNull) {
-				_wheelPos = QPoint(width(), height()) / 2;
-			} else {
-				_wheelPos += pixels;
-			}
-			_scroller->handleInput(wasNull
-				? QScroller::InputPress
-				: QScroller::InputMove, _wheelPos, e->timestamp());
-		} break;
-		case Qt::ScrollEnd:
-		case Qt::ScrollMomentum: {
-			if (!_wheelPos.isNull()) {
-				_scroller->handleInput(
-					QScroller::InputRelease,
-					_wheelPos,
-					e->timestamp());
-				_wheelPos = {};
-			}
-		} break;
-		}
-		return true;
 	}
-	return handleScrollEvent(
-		phase,
-		delta,
-		ignore,
-		touch,
-		crl::time(e->timestamp()));
-}
-
-bool ElasticScroll::requestBottomContent(int delta) {
-	if (!_bottomContentRequest
-		|| _insideBottomContentRequest
-		|| _overscroll
-		|| delta <= 0) {
-		return false;
-	}
-	const auto target = _state.visibleFrom + delta;
-	if (willScrollTo(target) >= target) {
-		return false;
-	}
-	const auto request = _bottomContentRequest;
-	const auto weak = base::make_weak(this);
-	_insideBottomContentRequest = true;
-	const auto result = request();
-	if (weak) {
-		_insideBottomContentRequest = false;
-	}
-	return result;
-}
-
-bool ElasticScroll::handleScrollEvent(
-		Qt::ScrollPhase phase,
-		int delta,
-		bool ignore,
-		bool touch,
-		crl::time timestamp) {
 	const auto momentum = (phase == Qt::ScrollMomentum)
 		|| (phase == Qt::ScrollEnd);
-	trackWheelVelocity(phase, delta, timestamp);
+	trackWheelVelocity(phase, delta, crl::time(e->timestamp()));
 	if (_ignoreMomentumFromOverscroll) {
 		if (!momentum) {
 			_ignoreMomentumFromOverscroll = 0;
@@ -1246,7 +1029,6 @@ bool ElasticScroll::handleScrollEvent(
 				if (!weak) {
 					return true;
 				}
-				ResendScrollerPrepare(_scroller);
 			}
 		}
 	}
@@ -1297,6 +1079,27 @@ bool ElasticScroll::handleScrollEvent(
 		overscrollReturn();
 	}
 	return true;
+}
+
+bool ElasticScroll::requestBottomContent(int delta) {
+	if (!_bottomContentRequest
+		|| _insideBottomContentRequest
+		|| _overscroll
+		|| delta <= 0) {
+		return false;
+	}
+	const auto target = _state.visibleFrom + delta;
+	if (willScrollTo(target) >= target) {
+		return false;
+	}
+	const auto request = _bottomContentRequest;
+	const auto weak = base::make_weak(this);
+	_insideBottomContentRequest = true;
+	const auto result = request();
+	if (weak) {
+		_insideBottomContentRequest = false;
+	}
+	return result;
 }
 
 void ElasticScroll::applyAccumulatedScroll() {
@@ -1870,7 +1673,6 @@ void ElasticScroll::scrollTo(int toFrom, int toTill) {
 		scTo += _overscroll;
 	}
 	applyScrollTo(scTo);
-	ResendScrollerPrepare(_scroller);
 }
 
 void ElasticScroll::doSetOwnedWidget(object_ptr<QWidget> w) {

--- a/ui/widgets/elastic_scroll.h
+++ b/ui/widgets/elastic_scroll.h
@@ -264,12 +264,6 @@ private:
 	void enterEventHook(QEnterEvent *e) override;
 	void leaveEventHook(QEvent *e) override;
 	bool handleWheelEvent(not_null<QWheelEvent*> e, bool touch = false);
-	bool handleScrollEvent(
-		Qt::ScrollPhase phase,
-		int delta,
-		bool ignore = false,
-		bool touch = false,
-		crl::time timestamp = 0);
 	bool requestBottomContent(int delta);
 	void handleTouchEvent(QTouchEvent *e);
 
@@ -320,7 +314,6 @@ private:
 		int delta,
 		crl::time timestamp);
 	void overscrollSpringStart(int side);
-	void overscrollBounce(int side, float64 velocity);
 	void overscrollSpringUpdate();
 	void updateBarState();
 	void overscrollSpringFinish();
@@ -331,9 +324,6 @@ private:
 	int _barBottomInset = 0;
 	int _contentBottomInset = 0;
 	ScrollState _state;
-
-	QPointer<QScroller> _scroller;
-	QPoint _wheelPos;
 
 	base::Timer _touchTimer;
 	base::Timer _touchScrollTimer;

--- a/ui/widgets/kinetic_scroller.cpp
+++ b/ui/widgets/kinetic_scroller.cpp
@@ -1,0 +1,480 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#include "ui/widgets/kinetic_scroller.h"
+
+#include "base/platform/base_platform_info.h"
+#include "base/options.h"
+#include "base/unique_qptr.h"
+#include "ui/ui_utility.h"
+
+#include <crl/crl_time.h>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QObject>
+#include <QtCore/QPointF>
+#include <QtCore/QPointer>
+#include <QtGui/QCursor>
+#include <QtGui/QPointingDevice>
+#include <QtGui/QtEvents>
+#include <QtGui/QWindow>
+#include <private/qguiapplication_p.h>
+#include <qpa/qwindowsysteminterface_p.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace Ui {
+
+const char kOptionKineticScroller[] = "kinetic-scroller";
+
+namespace {
+
+// Velocity decays as v0 * exp(-kFriction * t): ~170 ms half-life, the
+// total throw is v0 / kFriction - linear in the release velocity.
+constexpr auto kFriction = 4.; // 1 / s
+
+// Velocity is measured over the trailing window of drag deltas, so it
+// reflects the swiftness of the gesture tail no matter how long the whole
+// gesture was.
+constexpr auto kVelocityWindow = crl::time(150);
+
+// Finish the fling once the remaining throw can't move a pixel.
+constexpr auto kFlickRemainingThreshold = 0.5;
+
+base::options::toggle OptionKineticScroller({
+	.id = kOptionKineticScroller,
+	.name = "Custom kinetic scrolling for touchpads",
+	.defaultValue = Platform::IsLinux(),
+});
+
+// Replacement for QScroller: observes the phased wheel event stream of a
+// touchpad gesture to measure the release velocity, and after the release
+// synthesizes a stream of Qt::ScrollMomentum wheel events (finished by a
+// Qt::ScrollEnd one) with the proper exponential inertia curve similar to
+// what everyone else uses (GTK, Chromium, Firefox). The stream re-enters
+// Qt's window-system pipeline, so it follows the same targeting,
+// propagation, popup, modal, and wheel-grab paths as native momentum.
+//
+// QScroller not only has bad inertia curve, but also initializes the fling
+// with the wrong speed: its moving-average velocity estimate starts from
+// zero at press and each event pulls it only ~13% closer to the true speed,
+// taking ~135 ms of dragging to catch up, so the fling speed tracked
+// gesture length instead of the finger speed at release.
+//
+// Here the release velocity is averaged over the last 150 ms of drag deltas
+// and the fling decays it exponentially.
+//
+// One application-owned instance follows Qt's process-global wheel grab.
+class KineticScroller final : public QObject {
+public:
+	using QObject::QObject;
+
+	enum State {
+		Inactive,
+		Dragging,
+		Scrolling,
+	};
+
+	bool eventFilter(QObject *object, QEvent *event) override;
+
+private:
+	// The angle channel is echoed raw, so stock Qt wheel handling applies
+	// the fling at exactly the drag's rate. The pixel channel is raw too,
+	// with only the Wayland multiplier pre-applied: ScrollDeltaF skips it
+	// for the synthesized echo, but converts the rest uniformly.
+	struct DragSample {
+		crl::time time = 0;
+		QPointF angle;
+		QPointF pixel;
+	};
+
+	struct Velocity {
+		QPointF angle;
+		QPointF pixel;
+	};
+
+	[[nodiscard]] bool handleWheelEvent(
+		not_null<QWindow*> window,
+		not_null<QWheelEvent*> e);
+	void rememberInput(not_null<QWheelEvent*> e);
+	void interrupt(bool force);
+	[[nodiscard]] bool start(
+		not_null<QWindow*> window,
+		not_null<QWheelEvent*> e);
+	void end(bool force);
+	void drag(not_null<QWheelEvent*> e, crl::time timestamp);
+	[[nodiscard]] bool flick(crl::time timestamp);
+	void flickTick(crl::time now);
+	bool sendWheel(Qt::ScrollPhase phase, QPoint pixel, QPoint angle);
+	[[nodiscard]] Velocity dragVelocity(crl::time now) const;
+
+	QPointer<QWindow> _window;
+	QPointer<const QPointingDevice> _device;
+	QPoint _stopMousePos;
+	State _state = Inactive;
+	uint64 _generation = 0;
+	std::vector<DragSample> _history;
+	Qt::KeyboardModifiers _modifiers;
+	bool _inverted = false;
+	ulong _inputTimestamp = 0;
+	crl::time _inputReceivedAt = 0;
+
+	Velocity _flickVelocity;
+	QPointF _flickEmittedPixel;
+	QPointF _flickEmittedAngle;
+	crl::time _flickStarted = 0;
+
+};
+
+bool KineticScroller::handleWheelEvent(
+		not_null<QWindow*> window,
+		not_null<QWheelEvent*> e) {
+	const auto duplicate = (_window == window)
+		&& (e->timestamp() == _inputTimestamp)
+		&& e->pixelDelta().isNull()
+		&& e->angleDelta().isNull();
+	switch (e->phase()) {
+	case Qt::ScrollBegin:
+		if (_state == Dragging
+			&& _history.empty()
+			&& duplicate) {
+			rememberInput(e);
+		} else if (!start(window, e)) {
+			return false;
+		}
+		break;
+	case Qt::ScrollUpdate:
+		if (_window != window
+			|| _state == Inactive
+			|| _state == Scrolling) {
+			if (!start(window, e)) {
+				return false;
+			}
+		} else {
+			rememberInput(e);
+		}
+		drag(e, crl::time(e->timestamp()));
+		break;
+	case Qt::ScrollEnd:
+		if (_window != window) {
+			_state = Inactive;
+			break;
+		} else if (_state == Dragging) {
+			return flick(crl::time(e->timestamp()));
+		} else if (_state == Scrolling) {
+			if (duplicate) {
+				return true;
+			}
+			_state = Inactive;
+		}
+		break;
+	case Qt::ScrollMomentum:
+		if (_state != Inactive) {
+			if (_window == window) {
+				_state = Inactive;
+			} else {
+				interrupt(true);
+			}
+		}
+		break;
+	case Qt::NoScrollPhase:
+		break;
+	}
+	return false;
+}
+
+void KineticScroller::rememberInput(not_null<QWheelEvent*> e) {
+	_device = e->pointingDevice();
+	_modifiers = e->modifiers();
+	_inverted = e->inverted();
+	_inputTimestamp = ulong(e->timestamp());
+	_inputReceivedAt = crl::now();
+}
+
+void KineticScroller::interrupt(bool force) {
+	if (_state == Inactive) {
+		return;
+	}
+	const auto generation = _generation;
+	const auto previous = _modifiers;
+	const auto current = QGuiApplicationPrivate::modifier_buttons;
+	end(force);
+	if (generation == _generation
+		&& QGuiApplicationPrivate::modifier_buttons == previous) {
+		QGuiApplicationPrivate::modifier_buttons = current;
+	}
+}
+
+bool KineticScroller::start(
+		not_null<QWindow*> window,
+		not_null<QWheelEvent*> e) {
+	const auto generation = _generation;
+	const auto guardedWindow = QPointer<QWindow>(window.get());
+	interrupt(true);
+	if (!guardedWindow || generation != _generation) {
+		return false;
+	}
+	_window = guardedWindow;
+	rememberInput(e);
+	_history.clear();
+	_state = Dragging;
+	return true;
+}
+
+void KineticScroller::end(bool force) {
+	if (_state == Inactive) {
+		return;
+	}
+	const auto send = force || (_state == Scrolling);
+	_state = Inactive;
+	if (send) {
+		sendWheel(Qt::ScrollEnd, {}, {});
+	}
+}
+
+void KineticScroller::drag(
+		not_null<QWheelEvent*> e,
+		crl::time timestamp) {
+	if (e->pixelDelta().isNull() && e->angleDelta().isNull()) {
+		return;
+	}
+	while (!_history.empty()
+		&& _history.front().time < timestamp - kVelocityWindow) {
+		_history.erase(begin(_history));
+	}
+	_history.push_back({
+		.time = timestamp,
+		.angle = QPointF(e->angleDelta()),
+		.pixel = QPointF(e->pixelDelta())
+			* (::Platform::IsWayland() ? kMagicScrollMultiplier : 1.),
+	});
+}
+
+bool KineticScroller::flick(crl::time timestamp) {
+	_inputTimestamp = ulong(timestamp);
+	_inputReceivedAt = crl::now();
+	const auto velocity = dragVelocity(timestamp);
+	_history.clear();
+	const auto throwing = std::max(
+		std::abs(velocity.pixel.x()),
+		std::abs(velocity.pixel.y())) / kFriction;
+	if (throwing < kFlickRemainingThreshold) {
+		_state = Inactive;
+		return false;
+	}
+	_flickVelocity = velocity;
+	_flickEmittedPixel = QPointF();
+	_flickEmittedAngle = QPointF();
+	_flickStarted = crl::now();
+	_state = Scrolling;
+	_stopMousePos = QCursor::pos();
+	_window->requestUpdate();
+	return true;
+}
+
+void KineticScroller::flickTick(crl::time now) {
+	if (!_window) {
+		_state = Inactive;
+		return;
+	}
+	const auto time = (now - _flickStarted) / 1000.;
+	const auto progress = (1. - std::exp(-kFriction * time)) / kFriction;
+	// Truncation carries each channel's sub-quantum remainder with the
+	// correct sign, so the slow tail of the fling still progresses.
+	const auto quantum = [](QPointF wanted) {
+		return QPoint(
+			int(std::trunc(wanted.x())),
+			int(std::trunc(wanted.y())));
+	};
+	const auto pixel = quantum(
+		_flickVelocity.pixel * progress - _flickEmittedPixel);
+	const auto angle = quantum(
+		_flickVelocity.angle * progress - _flickEmittedAngle);
+	_flickEmittedPixel += pixel;
+	_flickEmittedAngle += angle;
+	if (!pixel.isNull() || !angle.isNull()) {
+		if (!sendWheel(
+			Qt::ScrollMomentum,
+			pixel,
+			angle)) {
+			return;
+		}
+	}
+	const auto remaining = std::exp(-kFriction * time) / kFriction;
+	const auto remainingThrow = std::max(
+		std::abs(_flickVelocity.pixel.x()),
+		std::abs(_flickVelocity.pixel.y())) * remaining;
+	if (remainingThrow < kFlickRemainingThreshold) {
+		end(false);
+	}
+}
+
+bool KineticScroller::sendWheel(
+		Qt::ScrollPhase phase,
+		QPoint pixel,
+		QPoint angle) {
+	const auto device = _device
+		? _device.data()
+		: QPointingDevice::primaryPointingDevice();
+	const auto window = _window;
+	if (!window) {
+		_state = Inactive;
+		return false;
+	}
+	const auto globalPosition = QPointF(QCursor::pos());
+	const auto position = window->mapFromGlobal(globalPosition);
+	const auto generation = _generation;
+	const auto was = _state;
+	const auto horizontal = !angle.y() && angle.x();
+	auto event = QWindowSystemInterfacePrivate::WheelEvent(
+		window.data(),
+		_inputTimestamp + ulong(std::max(
+			crl::time(0),
+			crl::now() - _inputReceivedAt)),
+		position,
+		globalPosition,
+		pixel,
+		angle,
+		horizontal ? angle.x() : angle.y(),
+		horizontal ? Qt::Horizontal : Qt::Vertical,
+		_modifiers,
+		phase,
+		Qt::MouseEventSynthesizedByApplication,
+		_inverted,
+		device);
+	if (const auto handler = QWindowSystemInterfacePrivate::eventHandler) {
+		handler->sendEvent(&event);
+	} else {
+		QGuiApplicationPrivate::processWindowSystemEvent(&event);
+	}
+	if (_state != was
+		|| generation != _generation) {
+		return false;
+	}
+	if (!window) {
+		_state = Inactive;
+		return false;
+	}
+	return true;
+}
+
+bool KineticScroller::eventFilter(
+		QObject *object,
+		QEvent *event) {
+	const auto type = event->type();
+	if (type != QEvent::Wheel
+		&& event->isInputEvent()
+		&& event->spontaneous()) {
+		++_generation;
+	}
+	if (type == QEvent::Wheel) {
+		if (!event->spontaneous()
+			|| !object->isWindowType()
+			|| !object->inherits("QWidgetWindow")) {
+			return false;
+		}
+		const auto window = static_cast<QWindow*>(object);
+		const auto e = static_cast<QWheelEvent*>(event);
+		const auto guardedWindow = QPointer<QWindow>(window);
+		if (e->phase() == Qt::NoScrollPhase) {
+			const auto generation = ++_generation;
+			interrupt(true);
+			return !guardedWindow || generation != _generation;
+		} else if (e->source() == Qt::MouseEventSynthesizedByApplication) {
+			return false;
+		}
+		const auto generation = ++_generation;
+		const auto consume = handleWheelEvent(window, e);
+		return consume
+			|| !guardedWindow
+			|| generation != _generation;
+	}
+	if (object != _window || _state != Scrolling) {
+		return false;
+	}
+	if (type == QEvent::UpdateRequest) {
+		const auto window = _window;
+		flickTick(crl::now());
+		if (_state == Scrolling && _window == window && window) {
+			window->requestUpdate();
+		}
+		// Consume: QWidgetWindow answers a window-level UpdateRequest
+		// with an unconditional full top-level repaint(). The scroll
+		// already invalidates exactly what it dirtied, and the widget
+		// repaint pipeline delivers its update requests to the widgets
+		// themselves, never through the window, so nothing is starved.
+		return true;
+	}
+	if (type == QEvent::MouseMove
+		|| type == QEvent::MouseButtonPress) {
+		if (!event->spontaneous()) {
+			return false;
+		}
+		const auto mouse = static_cast<QMouseEvent*>(event);
+		if (type == QEvent::MouseMove) {
+			if (_stopMousePos == mouse->globalPos()) {
+				return false;
+			}
+			_stopMousePos = mouse->globalPos();
+		}
+		const auto generation = _generation;
+		const auto guardedWindow = _window;
+		interrupt(false);
+		return !guardedWindow || generation != _generation;
+	}
+	return false;
+}
+
+KineticScroller::Velocity KineticScroller::dragVelocity(
+		crl::time now) const {
+	const auto first = std::find_if(
+		_history.begin(),
+		_history.end(),
+		[&](const auto &sample) {
+			return sample.time >= now - kVelocityWindow;
+		});
+	if (first == _history.end() || now <= first->time) {
+		return {};
+	}
+	auto from = first + 1;
+	if (from == _history.end()) {
+		from = first;
+	}
+	auto accumulated = Velocity();
+	for (auto i = from; i != _history.end(); ++i) {
+		accumulated.angle += i->angle;
+		accumulated.pixel += i->pixel;
+	}
+	const auto scale = 1000. / float64(now - first->time);
+	return {
+		.angle = accumulated.angle * scale,
+		.pixel = accumulated.pixel * scale,
+	};
+}
+
+void InstallKineticScroller() {
+	static const auto lifetime = rpl::single(
+		rpl::empty
+	) | rpl::then(
+		OptionKineticScroller.changes()
+	) | rpl::on_next([] {
+		static auto Scroller = base::unique_qptr<KineticScroller>();
+		Scroller = OptionKineticScroller.value()
+			? base::make_unique_q<KineticScroller>(qApp)
+			: nullptr;
+		if (!Scroller) {
+			return;
+		}
+		qApp->installEventFilter(Scroller.get());
+	});
+}
+
+Q_COREAPP_STARTUP_FUNCTION(InstallKineticScroller)
+
+} // namespace
+
+} // namespace Ui

--- a/ui/widgets/kinetic_scroller.h
+++ b/ui/widgets/kinetic_scroller.h
@@ -1,0 +1,17 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#pragma once
+
+#include <QtCore/QtGlobal>
+
+namespace Ui {
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+extern const char kOptionKineticScroller[];
+#endif
+
+} // namespace Ui

--- a/ui/widgets/scroll_area.cpp
+++ b/ui/widgets/scroll_area.cpp
@@ -8,30 +8,17 @@
 
 #include "ui/painter.h"
 #include "ui/ui_utility.h"
-#include "base/platform/base_platform_info.h"
 #include "base/qt/qt_common_adapters.h"
-#include "base/qt_signal_producer.h"
 #include "base/debug_log.h"
-#include "base/options.h"
 
 #include <QtWidgets/QScrollBar>
-#include <QtWidgets/QScroller>
-#include <QtWidgets/QScrollerProperties>
 #include <QtWidgets/QApplication>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QScreen>
 #include <QtGui/QWindow>
-#include <private/qabstractanimation_p.h>
 
 namespace Ui {
 namespace {
-
-base::options::toggle OptionQScroller({
-	.id = kOptionQScroller,
-	.name = "Use QScroller for touchpad scrolling",
-	.description = "Provides kinetic scrolling",
-	.defaultValue = Platform::IsLinux(),
-});
 
 [[nodiscard]] int ComputeScrollTo(
 		int toFrom,
@@ -71,138 +58,6 @@ base::options::toggle OptionQScroller({
 }
 
 } // namespace
-
-const char kOptionQScroller[] = "qscroller";
-
-void SetupScrollerPhysics(not_null<QScroller*> scroller) {
-	// Qt animates QScroller kinetic scrolling at fixed 16 ms / ~60 fps,
-	// so the inertia feels laggy on high refresh rate displays. Override
-	// the interval to match the highest refresh rate.
-	[[maybe_unused]] static const auto TimingIntervalUpdater = rpl::single(
-		rpl::empty
-	) | rpl::then(rpl::merge(
-		base::qt_signal_producer(qApp, &QGuiApplication::screenAdded),
-		base::qt_signal_producer(qApp, &QGuiApplication::screenRemoved)
-	) | rpl::to_empty) | rpl::map([] {
-		const auto screens = QGuiApplication::screens();
-		return rpl::combine(screens | ranges::views::transform([](
-				QScreen *screen) {
-			return rpl::single(
-				screen->refreshRate()
-			) | rpl::then(
-				base::qt_signal_producer(screen, &QScreen::refreshRateChanged)
-			) | rpl::type_erased;
-		}) | ranges::to_vector);
-	}) | rpl::flatten_latest(
-	) | rpl::on_next([](const auto &rates) {
-		QUnifiedTimer::instance()->setTimingInterval(
-			std::clamp(int(std::floor(1000. / ranges::max(rates))), 2, 16));
-	});
-
-	auto props = scroller->scrollerProperties();
-	using P = QScrollerProperties;
-	const auto set = [&](P::ScrollMetric metric, qreal value) {
-		props.setScrollMetric(metric, QVariant::fromValue(value));
-	};
-
-	// The Qt default 0.125 gives a ~4s, slippery, constant-deceleration
-	// glide that "never slows down". With the default OutQuad curve coast
-	// time ~= |v| / DecelerationFactor, so 0.6 brings a hard flick down
-	// to ~1-1.6s, close to macOS native momentum.
-	set(P::DecelerationFactor, 0.6);
-	// The default cap 0.5 m/s (~2165 px/s at ~110dpi) clips hard flicks below
-	// the legacy 2500-4000 px/s feel. NB: this metric is m/s, converted to
-	// pixels via pixelPerMeter = physicalDPI / 0.0254.
-	set(P::MaximumVelocity, 0.95);
-	// A touchpad feeds a continuous gesture stream, not discrete flicks, so
-	// re-pressing over a live fling makes accelerating-flick triple the
-	// release velocity each gesture until it saturates - 0 disables it.
-	set(P::AcceleratingFlickMaximumTime, 0.);
-	// A press onto a slow fling is taken for a click-through: the scroller
-	// goes Inactive, drops the press and eats the following moves.
-	// A touchpad has no clicks, so a press should just take over the fling.
-	set(P::MaximumClickThroughVelocity, 0.);
-	// The 5mm dead zone telling a touchscreen tap from a drag is pure loss
-	// here: it re-eats the first 5mm on every re-press and drops sub-5mm
-	// scrolls entirely. Touchpad events are always deliberate scrolls.
-	set(P::DragStartDistance, 0.);
-
-	// QScroller never does the overscroll itself: ScrollArea has none at
-	// all, and ElasticScroll implements its own rubber-band physics fed
-	// from the raw events, taking over at the edges.
-	props.setScrollMetric(
-		P::VerticalOvershootPolicy,
-		QVariant::fromValue(P::OvershootAlwaysOff));
-	props.setScrollMetric(
-		P::HorizontalOvershootPolicy,
-		QVariant::fromValue(P::OvershootAlwaysOff));
-
-	scroller->setScrollerProperties(props);
-}
-
-void ResendScrollerPrepare(QScroller *scroller) {
-	if (!scroller) {
-		return;
-	}
-	scroller->resendPrepareEvent();
-	if (scroller->state() != QScroller::Scrolling) {
-		return;
-	}
-	// setScrollerProperties() calls recalcScrollingSegments(true), rebuilding
-	// the in-flight segment from the current velocity - but only when the
-	// properties actually change. velocity() is derived from the segment's
-	// timing, not its start/stop positions, so this stays correct even on an
-	// unpatched QScroller. Perturb an input-only metric and restore it.
-	using P = QScrollerProperties;
-	constexpr auto metric = P::MousePressEventDelay;
-	const auto props = scroller->scrollerProperties();
-	auto tweaked = props;
-	tweaked.setScrollMetric(
-		metric,
-		QVariant::fromValue<qreal>(props.scrollMetric(metric).toReal() + 1.));
-	scroller->setScrollerProperties(tweaked);
-	scroller->setScrollerProperties(props);
-}
-
-ScrollerStopper::ScrollerStopper()
-: _mousePos(QCursor::pos()) {
-	qApp->installEventFilter(this);
-}
-
-ScrollerStopper &ScrollerStopper::Instance() {
-	static ScrollerStopper instance;
-	return instance;
-}
-
-void ScrollerStopper::activate(not_null<QScroller*> scroller) {
-	Expects(scroller->state() == QScroller::Scrolling);
-	_active = {
-		scroller.get(),
-		connect(
-			scroller,
-			&QScroller::stateChanged,
-			[=] { _active = {}; }),
-	};
-}
-
-bool ScrollerStopper::eventFilter(QObject *obj, QEvent *e) {
-	const auto type = e->type();
-	if (type != QEvent::MouseMove && type != QEvent::MouseButtonPress) {
-		return false;
-	}
-	const auto ev = static_cast<QMouseEvent*>(e);
-	if (type == QEvent::MouseMove) {
-		if (_mousePos == ev->globalPos()) {
-			return false;
-		}
-		_mousePos = ev->globalPos();
-	}
-	if (!_active.scroller) {
-		return false;
-	}
-	_active.scroller->stop();
-	return true;
-}
 
 // flick scroll taken from http://qt-project.org/doc/qt-4.8/demos-embedded-anomaly-src-flickcharm-cpp.html
 
@@ -589,33 +444,6 @@ ScrollArea::ScrollArea(
 		_touchTimer.setCallback([=] { _touchRightButton = true; });
 		_touchScrollTimer.setCallback([=] { touchScrollTimer(); });
 	}
-
-	rpl::single(
-		rpl::empty
-	) | rpl::then(
-		OptionQScroller.changes()
-	) | rpl::on_next([=] {
-		if (OptionQScroller.value()) {
-			_scroller = QScroller::scroller(this);
-			SetupScrollerPhysics(_scroller);
-		} else if (_scroller) {
-			QObject deleter;
-			_scroller->setParent(&deleter);
-		}
-
-		if (!_scroller) {
-			return;
-		}
-
-		connect(
-			_scroller,
-			&QScroller::stateChanged,
-			[=](QScroller::State state) {
-				if (state == QScroller::Scrolling) {
-					ScrollerStopper::Instance().activate(_scroller);
-				}
-			});
-	}, lifetime());
 }
 
 void ScrollArea::touchDeaccelerate(int32 elapsed) {
@@ -805,56 +633,6 @@ bool ScrollArea::viewportEvent(QEvent *e) {
 					&& _crossAxisWheelProcess(
 						{ qRound(delta.x()), 0 },
 						phase);
-			}
-		}
-		if (_scroller) {
-			switch (ev->phase()) {
-			case Qt::ScrollBegin:
-			case Qt::ScrollUpdate: {
-				if (ev->phase() == Qt::ScrollBegin
-					&& !ScrollDelta(ev).isNull()
-					&& _scroller->state() == QScroller::Scrolling) {
-					// On macOS, when Qt loses the race detecting that a
-					// momentum phase follows the finger lift, the OS
-					// momentum stream leaks through as ScrollBegin
-					// + ScrollMomentum. A real begin (fingers resting on
-					// the pad) carries a zero delta, so a delta-carrying
-					// begin while our fling runs is that leak - pressing
-					// would catch and kill the fling. If this ever
-					// swallows a real begin, the next ScrollUpdate finds
-					// _wheelPos null and presses instead.
-					return true;
-				}
-				const auto wasNull = _wheelPos.isNull();
-				if (wasNull) {
-					_wheelPos = QPoint(width(), height()) / 2;
-				} else {
-					auto unmultiplied = ScrollDelta(ev);
-					if (_wheelDirectionLocked) {
-						unmultiplied.setX(0);
-					}
-					const auto multiply = ev->modifiers()
-						& (Qt::ControlModifier | Qt::ShiftModifier);
-					_wheelPos += multiply
-						? QPoint(
-							unmultiplied.x() * std::max(width(), 120) / 120.,
-							unmultiplied.y() * std::max(height(), 120) / 120.)
-						: unmultiplied;
-				}
-				_scroller->handleInput(wasNull
-					? QScroller::InputPress
-					: QScroller::InputMove, _wheelPos, ev->timestamp());
-			} return true;
-			case Qt::ScrollEnd:
-			case Qt::ScrollMomentum: {
-				if (!_wheelPos.isNull()) {
-					_scroller->handleInput(
-						QScroller::InputRelease,
-						_wheelPos,
-						ev->timestamp());
-					_wheelPos = {};
-				}
-			} return true;
 			}
 		}
 	}
@@ -1114,7 +892,6 @@ void ScrollArea::scrollToX(int toLeft, int toRight) {
 
 void ScrollArea::scrollToY(int toTop, int toBottom) {
 	verticalScrollBar()->setValue(computeScrollToY(toTop, toBottom));
-	ResendScrollerPrepare(_scroller);
 }
 
 void ScrollArea::doSetOwnedWidget(object_ptr<QWidget> w) {

--- a/ui/widgets/scroll_area.h
+++ b/ui/widgets/scroll_area.h
@@ -10,14 +10,11 @@
 #include "ui/ui_utility.h"
 #include "ui/effects/animations.h"
 #include "base/object_ptr.h"
-#include "base/qt_connection.h"
 #include "base/timer.h"
 #include "styles/style_widgets.h"
 
 #include <QtWidgets/QScrollArea>
 #include <QtGui/QtEvents>
-
-class QScroller;
 
 namespace Ui {
 
@@ -46,42 +43,6 @@ struct ScrollToRequest {
 
 	int ymin = 0;
 	int ymax = 0;
-
-};
-
-extern const char kOptionQScroller[];
-
-// Tune a QScroller to approximate macOS native momentum. QScroller only
-// provides in-range kinetics: its overshoot is always disabled - ScrollArea
-// has no overscroll at all, and ElasticScroll implements its own rubber-band
-// overscroll physics fed from the raw events.
-void SetupScrollerPhysics(not_null<QScroller*> scroller);
-
-// Resends the scroll-prepare event and, while a fling is in progress, forces
-// the momentum segment to be rebuilt from the current velocity. QScroller bakes
-// the whole trajectory (including edge clamps) at gesture end and
-// resendPrepareEvent() only shifts it, so without the rebuild a fling stops at
-// the old (shifted) edge; with it, the fling flows into content inserted
-// mid-fling. Null- and state-safe.
-void ResendScrollerPrepare(QScroller *scroller);
-
-class ScrollerStopper final : public QObject {
-public:
-	static ScrollerStopper &Instance();
-
-	void activate(not_null<QScroller*> scroller);
-
-private:
-	ScrollerStopper();
-
-	bool eventFilter(QObject *obj, QEvent *e) override;
-
-	struct {
-		QPointer<QScroller> scroller;
-		base::qt_connection connection;
-	} _active;
-
-	QPoint _mousePos;
 
 };
 
@@ -284,9 +245,6 @@ private:
 	object_ptr<ScrollBar> _horizontalBar, _verticalBar;
 	object_ptr<ScrollShadow> _topShadow, _bottomShadow;
 	int _horizontalValue, _verticalValue;
-
-	QPointer<QScroller> _scroller;
-	QPoint _wheelPos;
 
 	bool _touchEnabled = false;
 	base::Timer _touchTimer;


### PR DESCRIPTION
`QScroller` has:
1. A bad inertia curve (all of the default ones).
2. A bad initial acceleration estimation.

These can't be properly tuned, so the only option is to reimplement `QScroller`.

This implementation's maths is based on Chromium and GTK4.

This also replaces the screen refresh rate heuristics with proper frame scheduling (vsync-accurate).

`KineticScroller` also exposes velocity directly, allowing more precise overscroll behavior without relying on estimated velocity from rounded per-tick deltas (fixing the spring suppression in the slow fling tails).