### PR TITLE
add explicit overscroll reset controls

### DIFF
--- a/ui/widgets/elastic_scroll.cpp
+++ b/ui/widgets/elastic_scroll.cpp
@@ -2009,6 +2009,24 @@ void ElasticScroll::setOverscrollDefaults(int from, int till, bool shift) {
 	}
 }
 
+void ElasticScroll::clearOverscroll() {
+	const auto from = _overscrollTypeFrom;
+	const auto till = _overscrollTypeTill;
+	setOverscrollDefaults(0, 0);
+	if (_overscroll < 0) {
+		setOverscrollTypes(OverscrollType::None, till);
+	} else if (_overscroll > 0) {
+		setOverscrollTypes(from, OverscrollType::None);
+	} else {
+		return;
+	}
+	setOverscrollTypes(from, till);
+}
+
+void ElasticScroll::returnToOverscrollDefaults() {
+	overscrollReturn();
+}
+
 void ElasticScroll::setOverscrollBg(QColor bg) {
 	_overscrollBg = bg;
 	update();

--- a/ui/widgets/elastic_scroll.h
+++ b/ui/widgets/elastic_scroll.h
@@ -199,6 +199,8 @@ public:
 	};
 	void setOverscrollTypes(OverscrollType from, OverscrollType till);
 	void setOverscrollDefaults(int from, int till, bool shift = false);
+	void clearOverscroll();
+	void returnToOverscrollDefaults();
 	void setOverscrollBg(QColor bg);
 	void setContentBottomInset(int inset);
 


### PR DESCRIPTION
callers had no explicit way to choose between cancelling overscroll immediately and animating it back to its default. they relied on programmatic scrolling or temporary overscroll type changes.

adds clearOverscroll() for immediate resets and returnToOverscrollDefaults() for animated returns.

this is a regression introduced by https://github.com/desktop-app/lib_ui/pull/323 T_T

written by gpt 5.6 sol.