### PR TITLE
Name the tooltip close button for screen readers

### DIFF
--- a/ui/widgets/tooltip.cpp
+++ b/ui/widgets/tooltip.cpp
@@ -6,6 +6,7 @@
 //
 #include "ui/widgets/tooltip.h"
 
+#include "ui/integration.h"
 #include "ui/ui_utility.h"
 #include "ui/painter.h"
 #include "ui/platform/ui_platform_utility.h"
@@ -527,6 +528,7 @@ object_ptr<RpWidget> MakeTooltipWithClose(
 	const auto button = CreateChild<IconButton>(
 		result.data(),
 		closeSt);
+	button->setAccessibleName(Integration::Instance().phraseButtonClose());
 	result->sizeValue(
 	) | rpl::on_next([=](QSize size) {
 		button->resize(button->width(), size.height());


### PR DESCRIPTION
The close button in MakeTooltipWithClose had no accessible name, so screen readers announced it as just "button". Now it uses Integration::phraseButtonClose(), the same way the window title close button does.