### PR TITLE
Fix X11 touchpad scrolling in elastic views

### DIFF
--- a/ui/ui_utility.cpp
+++ b/ui/ui_utility.cpp
@@ -7,6 +7,7 @@
 #include "ui/ui_utility.h"
 
 #include "base/platform/base_platform_info.h"
+#include "base/qt/qt_common_adapters.h"
 #include "ui/integration.h"
 #include "ui/style/style_core.h"
 
@@ -22,6 +23,7 @@ namespace {
 
 constexpr auto kDefaultWheelScrollLines = 3;
 constexpr auto kMagicScrollMultiplier = 2.5;
+constexpr auto kX11SmoothScrollMultiplier = 5.;
 
 class WidgetCreator : public QWidget {
 public:
@@ -272,18 +274,38 @@ QPointF ScrollDeltaF(not_null<QWheelEvent*> e, bool touch) {
 			style::ConvertScaleExact(point.x()),
 			style::ConvertScaleExact(point.y()));
 	};
+	const auto pixelDelta = e->pixelDelta();
+	const auto angleDelta = e->angleDelta();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
 	using QInputDevice::Capability::PixelScroll;
-	if (touch || e->device()->capabilities().testFlag(PixelScroll)) {
+	const auto pixelInput = touch
+		|| e->device()->capabilities().testFlag(PixelScroll);
 #else // Qt >= 6.2.0
-	if (!e->pixelDelta().isNull()) {
+	const auto pixelInput = !pixelDelta.isNull();
 #endif // Qt < 6.2.0
-		return convert(e->pixelDelta())
+	auto x11Touchpad = false;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	x11Touchpad = e->device()
+		&& e->device()->type() == base::TouchDevice::TouchPad;
+#endif // Qt >= 6.0.0
+	const auto x11Smooth = !touch
+		&& ::Platform::IsX11()
+		&& (pixelInput || !pixelDelta.isNull() || x11Touchpad);
+	if (x11Smooth && !angleDelta.isNull()) {
+		return (convert(angleDelta)
+			* QApplication::wheelScrollLines()
+			* kX11SmoothScrollMultiplier)
+			/ float64(QWheelEvent::DefaultDeltasPerStep);
+	}
+	if (pixelInput || (x11Smooth && !pixelDelta.isNull())) {
+		return (::Platform::IsX11() && !touch
+			? QPointF(pixelDelta)
+			: convert(pixelDelta))
 			* ((::Platform::IsWayland() && !touch)
 				? kMagicScrollMultiplier
 				: 1.);
 	}
-	return (convert(e->angleDelta()) * QApplication::wheelScrollLines())
+	return (convert(angleDelta) * QApplication::wheelScrollLines())
 		/ float64(kPixelToAngleDelta * kDefaultWheelScrollLines);
 }
 

--- a/ui/widgets/elastic_scroll.cpp
+++ b/ui/widgets/elastic_scroll.cpp
@@ -867,7 +867,7 @@ bool ElasticScroll::eventHook(QEvent *e) {
 	switch (e->type()) {
 	case QEvent::ScrollPrepare: {
 		QScrollPrepareEvent *se = static_cast<QScrollPrepareEvent *>(e);
-		se->setViewportSize(QSizeF(viewport()->size()));
+		se->setViewportSize(QSizeF(size()));
 		se->setContentPosRange(QRectF(
 			0,
 			0,
@@ -1029,21 +1029,29 @@ bool ElasticScroll::handleWheelEvent(not_null<QWheelEvent*> e, bool touch) {
 	const auto guard = gsl::finally([&] {
 		_lastScroll = now;
 	});
-	auto unmultiplied = ScrollDelta(e, touch);
+	if (phase == Qt::ScrollBegin) {
+		_wheelDeltaRemainder = {};
+	}
+	auto exactPixels = ScrollDeltaF(e, touch);
 	if (ownAxisLocked) {
 		if (_vertical) {
-			unmultiplied.setX(0);
+			exactPixels.setX(0.);
+			_wheelDeltaRemainder.setX(0.);
 		} else {
-			unmultiplied.setY(0);
+			exactPixels.setY(0.);
+			_wheelDeltaRemainder.setY(0.);
 		}
 	}
 	const auto multiply = e->modifiers()
 		& (Qt::ControlModifier | Qt::ShiftModifier);
-	const auto pixels = multiply
-		? QPoint(
-			(unmultiplied.x() * std::max(width(), 120) / 120.),
-			(unmultiplied.y() * std::max(height(), 120) / 120.))
-		: unmultiplied;
+	if (multiply) {
+		exactPixels = QPointF(
+			exactPixels.x() * std::max(width(), 120) / 120.,
+			exactPixels.y() * std::max(height(), 120) / 120.);
+	}
+	exactPixels += _wheelDeltaRemainder;
+	const auto pixels = exactPixels.toPoint();
+	_wheelDeltaRemainder = exactPixels - QPointF(pixels);
 	auto ignore = false;
 	auto delta = _vertical ? -pixels.y() : -pixels.x();
 	if (!ownAxisLocked
@@ -1092,7 +1100,7 @@ bool ElasticScroll::handleWheelEvent(not_null<QWheelEvent*> e, bool touch) {
 		case Qt::ScrollBegin:
 		case Qt::ScrollUpdate: {
 			if (phase == Qt::ScrollBegin
-				&& !pixels.isNull()
+				&& !exactPixels.isNull()
 				&& _scroller->state() == QScroller::Scrolling) {
 				// On macOS, when Qt loses the race detecting that a
 				// momentum phase follows the finger lift, the OS momentum

--- a/ui/widgets/elastic_scroll.h
+++ b/ui/widgets/elastic_scroll.h
@@ -334,6 +334,7 @@ private:
 
 	QPointer<QScroller> _scroller;
 	QPoint _wheelPos;
+	QPointF _wheelDeltaRemainder;
 
 	base::Timer _touchTimer;
 	base::Timer _touchScrollTimer;


### PR DESCRIPTION
Normalize smooth wheel input while preserving ordinary wheel behavior; retain fractional deltas and report the visible viewport to QScroller.