### PR TITLE
Fix -Wrestrict warning with gcc in initParagraphBidi()

### DIFF
--- a/ui/text/text_renderer.cpp
+++ b/ui/text/text_renderer.cpp
@@ -535,7 +535,7 @@ void Renderer::initNextLine() {
 }
 
 void Renderer::initParagraphBidi() {
-	if (!_paragraphLength || !_paragraphAnalysis.isEmpty()) {
+	if (_paragraphLength <= 0 || !_paragraphAnalysis.isEmpty()) {
 		return;
 	}
 


### PR DESCRIPTION
GCC assumes `_paragraphLength` can be negative, which triggers a false-positive `-Wrestrict` warning during `_paragraphAnalysis.resize()`. 

Checking `_paragraphLength <= 0` instead of `!_paragraphLength` prevents the compiler from assuming the length might be negative and cleanly silences the warning.

<details>
<summary>Build log</summary>

```text
In function 'void* memcpy(void*, const void*, size_t)',
    inlined from 'void QtPrivate::q_uninitialized_relocate_n(T*, N, T*) [with T = QScriptAnalysis; N = long long int]' at /usr/include/qt6/QtCore/qcontainertools_impl.h:79:24,
    inlined from 'void QtPrivate::q_uninitialized_relocate_n(T*, N, T*) [with T = QScriptAnalysis; N = long long int]' at /usr/include/qt6/QtCore/qcontainertools_impl.h:73:6,
    inlined from 'void QVLABase<T>::reallocate_impl(qsizetype, void*, qsizetype, qsizetype) [with T = QScriptAnalysis]' at /usr/include/qt6/QtCore/qvarlengtharray.h:939:46,
    inlined from 'void QVLABase<T>::resize_impl(qsizetype, void*, qsizetype) [with T = QScriptAnalysis]' at /usr/include/qt6/QtCore/qvarlengtharray.h:251:24,
    inlined from 'void QVarLengthArray<T, Prealloc>::resize(qsizetype) [with T = QScriptAnalysis; long long int Prealloc = 4096]' at /usr/include/qt6/QtCore/qvarlengtharray.h:455:50,
    inlined from 'void Ui::Text::Renderer::initParagraphBidi()' at ui/text/text_renderer.cpp:542:27:
/usr/include/bits/string_fortified.h:29:33: warning: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' accessing 18446744065119617024 or more bytes at offsets 31208 and 0 overlaps 9223372019674906625 bytes at offset -9223372028264841217 [-Wrestrict]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>