### PR TITLE
Fix SeparatePanel fullscreen origin by clearing WA_Moved

### DIFF
--- a/ui/widgets/separate_panel.cpp
+++ b/ui/widgets/separate_panel.cpp
@@ -1387,6 +1387,13 @@ QRect SeparatePanel::innerGeometry() const {
 void SeparatePanel::toggleFullScreen(bool fullscreen) {
 	_fullscreen = fullscreen;
 	if (fullscreen) {
+		// RpWidget's constructor calls setGeometry(0, 0, 0, 0), which sets
+		// WA_Moved. After that Qt treats the panel as explicitly positioned
+		// and QWidget::show() / QWidgetPrivate::create pass that position to
+		// the QWindow instead of letting the platform place a fullscreen
+		// window at the screen origin (resize-only). Same workaround as the
+		// Linux transient-parent path in initGeometry().
+		setAttribute(Qt::WA_Moved, false);
 		showFullScreen();
 	} else {
 		showNormal();


### PR DESCRIPTION
## Summary
- Clear `Qt::WA_Moved` on `SeparatePanel` before `showFullScreen()`, so Qt can place the frameless Mini App panel at the screen origin instead of only resizing it.
- Follows the Linux transient-parent path in `initGeometry()`, which already clears `WA_Moved` after `RpWidget`'s constructor `setGeometry(0, 0, 0, 0)`.

## Context
Reported in telegramdesktop/tdesktop#30963 (also #31041 / #31114).

This supersedes #342. That PR forced screen geometry after `showFullScreen()` and blamed QTBUG-39537 / QTBUG-86899. @ilya-fedin pointed out those bugs are unrelated/fixed, and that the real issue is likely ours: Qt only auto-positions unless `setGeometry()` / `move()` were called, so `WA_Moved` from `RpWidget` keeps Mini Apps anchored at the pre-fullscreen origin.

Forcing `SetGeometryAndScreen()` after `showFullScreen()` is also the wrong tool: `setGeometry_sys()` clears `Qt::WindowFullScreen` when not inside `setWindowState()`.

## Test plan
- [ ] Windows, single monitor: open a Mini App, enter fullscreen via UI or `web_app_request_fullscreen` — panel should cover the full screen from the monitor origin.
- [ ] Windows, two monitors: main Telegram window mid-primary; open Mini App fullscreen — panel should cover the primary screen, not remain centered over the main window and overflow.
- [ ] Open a Mini App that requests fullscreen immediately — same full-screen origin.
- [ ] Exit fullscreen — panel returns to the normal anchored size/position.
- [ ] Linux/macOS smoke: Mini App fullscreen still enters/exits correctly.


Made with [Cursor](https://cursor.com)