### PR TITLE
Say what announces a focused accessibility child

### DIFF
--- a/ui/accessible/ui_accessible_widget.cpp
+++ b/ui/accessible/ui_accessible_widget.cpp
@@ -269,11 +269,11 @@ QStringList Widget::actionNames() const {
 }
 
 void Widget::doAction(const QString &actionName) {
-	// On Qt 5 the Windows UIA bridge redirects a container's SetFocus to
-	// focusChild() only for an element exposing a table interface, not for a
-	// List - so focus would land on the inert container. Forward SetFocus to
-	// the selected item's widget directly instead (no extra Qt patch needed).
-	// Opt-in, so only a selection list (the folder strip) is affected.
+	// The items of a selection list are real widgets and it is they, not the
+	// container, that keep the keyboard focus: they handle the arrow keys and
+	// carry the list's single Tab-stop. So a container SetFocus has to land on
+	// the selected item - taking focus there announces it by itself. Opt-in,
+	// so only a selection list (the folder strip) is affected.
 	if (actionName == QAccessibleActionInterface::setFocusAction()
 		&& rp()->accessibilitySelectionList()) {
 		if (const auto selected = selectedItem(0)) {

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -463,6 +463,15 @@ public:
 	[[nodiscard]] virtual QAccessible::Role accessibilityChildSubItemRole() const;
 	[[nodiscard]] virtual QString accessibilityChildSubItemName(int row, int column) const;
 	[[nodiscard]] virtual QString accessibilityChildSubItemValue(int row, int column) const;
+
+	// Announces a child as the one holding accessible focus. Meant for a
+	// browse position that moves while keyboard focus stays put - arrow keys
+	// inside a painted list, say. Taking keyboard focus needs no call: that
+	// raises a focus event of its own which the platform resolves through
+	// focusChild(), so announcing the child here as well reads it twice; make
+	// sure focusChild() points at the right one before focus-in returns
+	// instead. (On Windows that resolution needs Qt 6.2 or the focus child
+	// notification backported into the 5.15 build.)
 	void accessibilityChildFocused(int index);
 
 	// Per-child opt-in for the accessibility action interface (SetFocus /


### PR DESCRIPTION
Two comments, no behaviour change.

A widget taking keyboard focus raises a focus event which the platform resolves through focusChild(), so a painted list that also announces its current child from focusInEvent has it read twice. That is written down now next to accessibilityChildFocused(), which is where the mistake gets made - telegramdesktop/tdesktop#31169 removes five of those announcements.

The other comment was wrong: the container SetFocus we handle in Widget::doAction() is not a workaround for the bridge not redirecting focus. It is there because a selection list keeps keyboard focus on its items - they are real widgets handling the arrow keys and carrying the list's single Tab-stop - so focus has to reach the selected item rather than the container.