### PR TITLE
Add a selection event for a painted list child

### DIFF
--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -457,6 +457,12 @@ void RpWidget::accessibilityChildStateChanged(
 	QAccessible::updateAccessibility(&event);
 }
 
+void RpWidget::accessibilityChildSelectionChanged(int index) {
+	auto event = QAccessibleEvent(this, QAccessible::SelectionAdd);
+	event.setChild(index);
+	QAccessible::updateAccessibility(&event);
+}
+
 void RpWidget::accessibilityChildFocused(int index) {
 	QAccessibleEvent event(this, QAccessible::Focus);
 	event.setChild(index);

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -457,6 +457,16 @@ public:
 	void accessibilityChildValueChanged(int index);
 	[[nodiscard]] virtual QAccessible::State accessibilityChildState(int index) const;
 	void accessibilityChildStateChanged(int index, AccessibilityState changes);
+
+	// Announces that a child was selected or deselected. A state change does
+	// not cover it: the Windows bridge looks at the checked flag there and
+	// ignores the selected one. Both directions raise the same event, the one
+	// that bridge forwards (SelectionRemove reaches no one) - a screen reader
+	// reads the new value off the child and announces the difference, so it
+	// only needs telling that the selection changed. SideBarButton does the
+	// same for the folders that are real widgets.
+	void accessibilityChildSelectionChanged(int index);
+
 	[[nodiscard]] virtual QAccessible::Role accessibilityChildRole() const;
 	[[nodiscard]] virtual QRect accessibilityChildRect(int index) const;
 	[[nodiscard]] virtual int accessibilityChildColumnCount(int row) const;


### PR DESCRIPTION
A painted list has no way to tell a screen reader that a row became the current one, or stopped being. accessibilityChildStateChanged() with the selected flag looks like it should do it, but on Windows the bridge reads only the checked flag out of a state change (qwindowsuiamainprovider.cpp, notifyStateChange). So the chat folder tabs stayed silent on activation, while the folders that are real widgets say "selected" - SideBarButton::setActive() raises the selection event itself.

accessibilityChildSelectionChanged(index) does the same for a virtual child. It raises SelectionAdd for a deselection as well, which reads odd but is deliberate: SelectionRemove is mapped nowhere in the bridge (in qtbase dev either, not just 5.15), and a screen reader reads the new value off the child and announces the difference - so it only needs telling that the selection of this child changed. Verified in a log: NVDA answers the event with a state comparison, saying just "selected" or "not selected", and stays quiet when the value did not actually change.

Used by telegramdesktop/tdesktop#31097 when a slider section is activated, and by telegramdesktop/tdesktop#31171 when a message is selected or deselected. Both verified with NVDA on Windows 10.