### PR TITLE
Fixed transient parent of submenu windows on Wayland.

### DIFF
--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -44,7 +44,11 @@ namespace {
 
 void ToggleChildrenVisibility(not_null<QWidget*> widget, bool visible) {
 	for (const auto &child : GetChildWidgets(widget)) {
-		if (child) {
+		// Children that are windows themselves, like submenu windows of a
+		// popup menu, manage their own visibility, QWidget::hideChildren()
+		// skips them as well. Toggling them here would map and unmap their
+		// surfaces in the middle of an unrelated animation.
+		if (child && !child->isWindow()) {
 			child->setVisible(visible);
 		}
 	}

--- a/ui/widgets/popup_menu.cpp
+++ b/ui/widgets/popup_menu.cpp
@@ -94,7 +94,7 @@ PopupMenu::PopupMenu(QWidget *parent, QMenu *menu, const style::PopupMenu &st)
 		if (const auto submenu = action->menu()) {
 			_submenus.emplace(
 				action,
-				base::make_unique_q<PopupMenu>(parentWidget(), submenu, st)
+				base::make_unique_q<PopupMenu>(this, submenu, st)
 			).first->second->deleteOnHide(false);
 		}
 	}
@@ -151,7 +151,7 @@ not_null<PopupMenu*> PopupMenu::ensureSubmenu(
 	}
 	const auto result = _submenus.emplace(
 		action,
-		base::make_unique_q<PopupMenu>(parentWidget(), st)
+		base::make_unique_q<PopupMenu>(this, st)
 	).first->second.get();
 	result->deleteOnHide(false);
 	return result;
@@ -283,13 +283,14 @@ not_null<QAction*> PopupMenu::addAction(
 		action,
 		base::unique_qptr<PopupMenu>(submenu.release())
 	).first->second.get();
-	// Reparent under our own parent (like ensureSubmenu and the QMenu
-	// constructor do), but keep the window flags: the single-argument
+	// Reparent under the menu itself (like ensureSubmenu and the QMenu
+	// constructor do), so the submenu window gets this menu's window as
+	// its transient parent, but keep the window flags: the single-argument
 	// QWidget::setParent() resets them, which strips the Qt::Popup type set
 	// in init() and demotes the submenu to a plain child widget. Such a widget
 	// has no windowHandle() after createWinId(), so prepareGeometryFor() can't
 	// show it.
-	saved->setParent(parentWidget(), saved->windowFlags());
+	saved->setParent(this, saved->windowFlags());
 	saved->deleteOnHide(false);
 	return action;
 }


### PR DESCRIPTION
On Wayland every submenu produced a warning from the QPA plugin:

```
qt.qpa.wayland: Creating a popup with a parent, QWidgetWindow(...) which does not
match the current topmost grabbing popup, QWidgetWindow(...) With some shell surface
protocols, this is not allowed. ... Please fix the transient parent of the popup.
```

Submenus were parented to the menu's own parent widget, so their windows got the
main window as the transient parent instead of the menu that spawned them —
`QWidgetPrivate::create()` takes it from `nativeParentWidget()->window()`. Qt then
silently repointed the parent at the topmost grabbing popup. Parenting a submenu to
the menu itself is what `QMenu::addMenu()` does as well.

That alone was not enough. Once submenu windows became child widgets of the menu,
`ToggleChildrenVisibility()` started toggling them along with the ordinary children,
so `PopupMenu::prepareCache()` unmapped and remapped submenu surfaces in the middle
of the menu's own show/hide animation, creating popups at moments when the topmost
popup was a different one. `QWidgetPrivate::hideChildren()` skips children that are
windows for exactly this reason, so do the same here.

Verified on Hyprland with a Qt 6.11.1 build: submenu windows now get their menu as
the transient parent and no warnings are left, including repeated opening of the
same submenu, which previously kept warning once the plugin's state went wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
