### PR TITLE
Select a word with an apostrophe in it as one word.

### DIFF
--- a/ui/text/text.cpp
+++ b/ui/text/text.cpp
@@ -1512,16 +1512,16 @@ TextSelection String::adjustSelection(TextSelection selection, TextSelectType se
 				}
 			}
 		} else if (selectType == TextSelectType::Words) {
-			if (!IsWordSeparator(_text.at(from))) {
-				while (from > 0 && !IsWordSeparator(_text.at(from - 1))) {
+			if (!IsWordSeparator(_text, from)) {
+				while (from > 0 && !IsWordSeparator(_text, from - 1)) {
 					--from;
 				}
 			}
 			if (to < _text.size()) {
-				if (IsWordSeparator(_text.at(to))) {
+				if (IsWordSeparator(_text, to)) {
 					++to;
 				} else {
-					while (to < _text.size() && !IsWordSeparator(_text.at(to))) {
+					while (to < _text.size() && !IsWordSeparator(_text, to)) {
 						++to;
 					}
 				}
@@ -2301,6 +2301,48 @@ bool IsWordSeparator(QChar ch) {
 		break;
 	}
 	return false;
+}
+
+// Given the neighbours, unlike the one above, an apostrophe can be seen for
+// what it is: a part of the word it stands in, so that "don't" is one word,
+// and a separator only when it is doubled or stands at the edge of a word -
+// the same rule the patched Qt applies in QTextEngine::toEdge().
+template <typename At>
+[[nodiscard]] bool IsWordSeparatorWith(At &&at, int length, int position) {
+	if (position < 0 || position >= length) {
+		return true;
+	}
+	const auto ch = at(position);
+	const auto unicode = ch.unicode();
+	const auto apostrophe = (unicode == '\'')
+		|| (unicode == 0x2018) // left single quotation mark
+		|| (unicode == 0x2019); // right single quotation mark
+	if (!apostrophe) {
+		return IsWordSeparator(ch);
+	}
+
+	// A doubled apostrophe is just the case of the neighbour being one, and
+	// the list above already calls an apostrophe a separator, so both that
+	// and the edge of a word are the same question asked to the sides.
+	const auto edge = [&](int index) {
+		return (index < 0)
+			|| (index >= length)
+			|| IsWordSeparator(at(index));
+	};
+	return edge(position - 1) || edge(position + 1);
+}
+
+bool IsWordSeparator(const QString &text, int position) {
+	return IsWordSeparatorWith(
+		[&](int index) { return text.at(index); },
+		int(text.size()),
+		position);
+}
+
+// For the text that is not in a string of its own - a block of a document is
+// read a character at a time instead of being copied for every question.
+bool IsWordSeparator(Fn<QChar(int)> at, int length, int position) {
+	return IsWordSeparatorWith(at, length, position);
 }
 
 bool IsAlmostLinkEnd(QChar ch) {

--- a/ui/text/text.h
+++ b/ui/text/text.h
@@ -569,6 +569,11 @@ private:
 
 [[nodiscard]] bool IsBad(QChar ch);
 [[nodiscard]] bool IsWordSeparator(QChar ch);
+[[nodiscard]] bool IsWordSeparator(const QString &text, int position);
+[[nodiscard]] bool IsWordSeparator(
+	Fn<QChar(int)> at,
+	int length,
+	int position);
 [[nodiscard]] bool IsAlmostLinkEnd(QChar ch);
 [[nodiscard]] bool IsLinkEnd(QChar ch);
 [[nodiscard]] bool IsNewline(QChar ch);


### PR DESCRIPTION
`IsWordSeparator()` is a copy of Qt's `QTextEngine::atWordSeparator()` list, made
back in 2014, and it has the apostrophe in it. Selecting by words - a double
click, or `TextSelectType::Words` in `adjustSelection()` - therefore cuts `don't`
down to `don`, `it's` to `it`, `o'clock` to `o`.

Qt itself has the same problem, and one of the Qt patches of the official builds
fixes it there: an apostrophe is a separator only when it is doubled or when it
stands at the edge of a word, so `don't` is one word while `don''t` and
`'quoted'` are not. This applies the same rule here, where the text is ours to
look at, so the selection no longer depends on that patch.

The rule needs the neighbours of a character, so it comes as an overload that is
given the text along with the position. There are two of them: one for a text
that is already a string, and one that reads a character at a time - a block of
a `QTextDocument` answers that without copying itself for every question, which
is what `lib_spellcheck` needs for the word under the cursor. The plain
character overload keeps the list as it was, for the callers that have a single
character and no way to look around it.

Verified against `QTextCursor::WordUnderCursor` on every position of a set of
samples: `don't`, `it's`, `o'clock`, `donn't`, `a'b` come out as one word,
`don''t` as two, and the quotes of `'quoted'` and `rock 'n' roll` stay outside.
