### PR TITLE
Fixed submenu painted over the menu in its show animation.

### DIFF
--- a/ui/widgets/popup_menu.cpp
+++ b/ui/widgets/popup_menu.cpp
@@ -909,7 +909,12 @@ QImage PopupMenu::grabForPanelAnimation() {
 		p.fillRect(_inner, _st.menu.itemBg);
 		for (const auto child : children()) {
 			if (const auto widget = qobject_cast<QWidget*>(child)) {
-				RenderWidget(p, widget, widget->pos());
+				// Submenus are windows of their own, they are not a part
+				// of what this menu paints, and their pos() is meaningless
+				// in our coordinates.
+				if (!widget->isWindow()) {
+					RenderWidget(p, widget, widget->pos());
+				}
 			}
 		}
 		_grabbingForPanelAnimation = false;


### PR DESCRIPTION
Fixes telegramdesktop/tdesktop#31186: right clicking a chat shows the contents of
a submenu (the folder list) over the menu for the duration of the show animation.

A regression from #347. `grabForPanelAnimation()` renders every child widget into
the animation cache, and since submenus became child widgets of the menu they are
rendered too - at a `pos()` that means nothing in the menu's coordinates. They are
windows of their own and paint themselves, so skip them here, the same way
`ToggleChildrenVisibility()` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
