### PR TITLE
Fix ElasticScroll's QScroller viewport size

### DIFF
--- a/ui/widgets/elastic_scroll.cpp
+++ b/ui/widgets/elastic_scroll.cpp
@@ -867,7 +867,7 @@ bool ElasticScroll::eventHook(QEvent *e) {
 	switch (e->type()) {
 	case QEvent::ScrollPrepare: {
 		QScrollPrepareEvent *se = static_cast<QScrollPrepareEvent *>(e);
-		se->setViewportSize(QSizeF(viewport()->size()));
+		se->setViewportSize(QSizeF(size()));
 		se->setContentPosRange(QRectF(
 			0,
 			0,


### PR DESCRIPTION
It expects the visible size, not the child widget's full size