### PR TITLE
Accessibility: announce context menu open to screen readers

### DIFF
--- a/ui/widgets/popup_menu.cpp
+++ b/ui/widgets/popup_menu.cpp
@@ -23,6 +23,7 @@
 #include "ui/ui_utility.h"
 
 #include <QtGui/QtEvents>
+#include <QtGui/QAccessible>
 #include <QtGui/QPainter>
 #include <QtGui/QScreen>
 #include <QtGui/QWindow>
@@ -1157,6 +1158,8 @@ void PopupMenu::showPrepared(TriggeredSource source) {
 	activateWindow();
 	if (Ui::ScreenReaderModeActive()) {
 		_menu->setShowSource(TriggeredSource::Keyboard);
+		QAccessibleEvent event(this, QAccessible::Focus);
+		QAccessible::updateAccessibility(&event);
 	} else {
 		_menu->setShowSource(source);
 	}


### PR DESCRIPTION
## Summary

When a `Ui::PopupMenu` opens while a screen reader is active, fire a `QAccessible::Focus` event on the menu so NVDA/JAWS/ORCA announce it immediately (part of issue telegramdesktop/tdesktop#476).

This is a self-contained change: it only emits an accessibility event in `PopupMenu::showPrepared()` when `Ui::ScreenReaderModeActive()` is true; no menu logic or focus behavior is altered.

## Changes

- `ui/widgets/popup_menu.cpp`: include `<QtGui/QAccessible>` and fire `QAccessible::Focus` on the menu after show under a screen reader.

## Related

- Consumed by telegramdesktop/tdesktop (PR `feat/accessibility-complete-overhaul`).
- Issue: telegramdesktop/tdesktop#476



---

## Verification status

Phase 2-4 features implemented. Full functional verification requires a Qt6 build environment (the desktop-app Linux build compiles patched Qt6 from source inside Docker, which was not available in the implementation environment). **CI validation requested.** The `lib_ui` submodule must be updated to this branch head for the tdesktop side to build against the new accessible sub-item framework.
