### PR TITLE
Let one list child report its own accessibility role

### DIFF
--- a/ui/accessible/ui_accessible_item.cpp
+++ b/ui/accessible/ui_accessible_item.cpp
@@ -91,7 +91,10 @@ QWindow *Item::window() const {
 
 QAccessible::Role Item::role() const {
 	const auto parent = _parent.get();
-	return parent
+	const auto index = parent ? currentIndex() : -1;
+	return (index >= 0)
+		? parent->accessibilityChildRoleAt(index)
+		: parent
 		? parent->accessibilityChildRole()
 		: QAccessible::Role();
 }

--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -402,6 +402,10 @@ QAccessible::Role RpWidget::accessibilityChildRole() const {
 	return QAccessible::Role::NoRole;
 }
 
+QAccessible::Role RpWidget::accessibilityChildRoleAt(int index) const {
+	return accessibilityChildRole();
+}
+
 QString RpWidget::accessibilityChildName(int index) const {
 	return QString();
 }

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -458,6 +458,13 @@ public:
 	[[nodiscard]] virtual QAccessible::State accessibilityChildState(int index) const;
 	void accessibilityChildStateChanged(int index, AccessibilityState changes);
 	[[nodiscard]] virtual QAccessible::Role accessibilityChildRole() const;
+
+	// The role of one child where it differs from the list-wide one above:
+	// a divider row between the items of a list is a Separator, not one
+	// more item. Defaults to accessibilityChildRole().
+	[[nodiscard]] virtual QAccessible::Role accessibilityChildRoleAt(
+		int index) const;
+
 	[[nodiscard]] virtual QRect accessibilityChildRect(int index) const;
 	[[nodiscard]] virtual int accessibilityChildColumnCount(int row) const;
 	[[nodiscard]] virtual QAccessible::Role accessibilityChildSubItemRole() const;


### PR DESCRIPTION
A painted list reports one role for all of its virtual children through accessibilityChildRole(), so a row that is not an item - the unread bar dividing the read messages from the unread ones in the message lists - was read as a list item as well.

accessibilityChildRoleAt(index) lets the owner give one child its own role and defaults to the list-wide one, so nothing changes for the existing lists. It is a separate name rather than an overload on purpose: an overloaded virtual makes clang's -Woverloaded-virtual fail every class that overrides only one of the two forms under the -Werror builds.

Used by telegramdesktop/tdesktop#31211 to expose the unread bar as a Separator, verified with NVDA on Windows 10: the bar is announced as "Unread messages, separator" and drops out of the selection item pattern, the messages around it are unchanged.
