### PR TITLE
Report the position of a painted list item within its set

### DIFF
--- a/ui/accessible/ui_accessible_item.cpp
+++ b/ui/accessible/ui_accessible_item.cpp
@@ -198,18 +198,47 @@ QAccessibleInterface *Item::parent() const {
 }
 
 void *Item::interface_cast(QAccessible::InterfaceType type) {
+	const auto parent = _parent.get();
+	const auto index = parent ? currentIndex() : -1;
 	if (type == QAccessible::ActionInterface) {
 		// Expose the action interface only when the owner opted in for this
 		// child. Otherwise the Windows UIA bridge would advertise Invoke /
 		// SetFocus / SelectionItem and report success while doing nothing.
-		const auto parent = _parent.get();
-		const auto index = parent ? currentIndex() : -1;
 		if (index >= 0
 			&& parent->accessibilityChildSupportsActions(index)) {
 			return static_cast<QAccessibleActionInterface*>(this);
 		}
+	} else if (type == QAccessible::AttributesInterface) {
+		// Only a row that is one of the set reports a position, a divider
+		// between the rows has none - see accessibilityChildSetPosition.
+		if (index >= 0
+			&& parent->accessibilityChildSetPosition(index).position > 0) {
+			return static_cast<QAccessibleAttributesInterface*>(this);
+		}
 	}
 	return nullptr;
+}
+
+QList<QAccessible::Attribute> Item::attributeKeys() const {
+	return {
+		QAccessible::Attribute::PositionInSet,
+		QAccessible::Attribute::SizeOfSet,
+	};
+}
+
+QVariant Item::attributeValue(QAccessible::Attribute key) const {
+	const auto parent = _parent.get();
+	const auto index = parent ? currentIndex() : -1;
+	if (index < 0) {
+		return QVariant();
+	}
+	const auto position = parent->accessibilityChildSetPosition(index);
+	if (key == QAccessible::Attribute::PositionInSet) {
+		return position.position;
+	} else if (key == QAccessible::Attribute::SizeOfSet) {
+		return position.size;
+	}
+	return QVariant();
 }
 
 QStringList Item::actionNames() const {

--- a/ui/accessible/ui_accessible_item.h
+++ b/ui/accessible/ui_accessible_item.h
@@ -86,7 +86,8 @@ struct SubItems {
 
 class Item final
 	: public QAccessibleInterface
-	, public QAccessibleActionInterface {
+	, public QAccessibleActionInterface
+	, public QAccessibleAttributesInterface {
 public:
 	Item(not_null<RpWidget*> parent, int index);
 
@@ -130,6 +131,10 @@ public:
 	void doAction(const QString &actionName) override;
 	QStringList keyBindingsForAction(
 		const QString &actionName) const override;
+
+	// QAccessibleAttributesInterface.
+	QList<QAccessible::Attribute> attributeKeys() const override;
+	QVariant attributeValue(QAccessible::Attribute key) const override;
 
 private:
 	base::weak_qptr<RpWidget> _parent;

--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -402,6 +402,11 @@ QAccessible::Role RpWidget::accessibilityChildRole() const {
 	return QAccessible::Role::NoRole;
 }
 
+AccessibilitySetPosition RpWidget::accessibilityChildSetPosition(
+		int index) const {
+	return { index + 1, accessibilityChildCount() };
+}
+
 QString RpWidget::accessibilityChildName(int index) const {
 	return QString();
 }

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -380,6 +380,15 @@ private:
 // Add required fields from QAccessible::State when necessary.
 // Don't forget to amend the AccessibilityState::writeTo implementation.
 // This one allows universal initialization, like { .checkable = true }.
+// The "x of y" of a child of a painted list, reported to a screen reader
+// as PositionInSet / SizeOfSet: the 1-based position of the child within
+// the set of its siblings and the size of that set. A zero position means
+// the child is not one of the set, like a divider row between the items.
+struct AccessibilitySetPosition {
+	int position = 0;
+	int size = 0;
+};
+
 struct AccessibilityState {
 	bool checkable : 1 = false;
 	bool checked : 1 = false;
@@ -458,6 +467,12 @@ public:
 	[[nodiscard]] virtual QAccessible::State accessibilityChildState(int index) const;
 	void accessibilityChildStateChanged(int index, AccessibilityState changes);
 	[[nodiscard]] virtual QAccessible::Role accessibilityChildRole() const;
+
+	// By default every child is one of the set; a list with rows outside
+	// it overrides this to skip them, see AccessibilitySetPosition.
+	[[nodiscard]] virtual AccessibilitySetPosition accessibilityChildSetPosition(
+		int index) const;
+
 	[[nodiscard]] virtual QRect accessibilityChildRect(int index) const;
 	[[nodiscard]] virtual int accessibilityChildColumnCount(int row) const;
 	[[nodiscard]] virtual QAccessible::Role accessibilityChildSubItemRole() const;


### PR DESCRIPTION
A painted list item had no way to tell a screen reader which of how many rows it is, so the lists that are real widgets say "2 of 10" while the painted ones stay silent about it.

Item reports it now through the accessibility attributes interface, as the PositionInSet / SizeOfSet attributes the Windows UIA bridge maps to the properties a screen reader announces. The numbers come from the owner through accessibilityChildSetPosition(): by default every child is one of the set (index + 1 of the child count), and a list with rows that are not items - a divider between them - overrides it to leave those out, so they neither get a position nor shift the ones below. A row outside the set does not expose the interface at all.

The two attributes are in Qt since 6.13 (https://codereview.qt-project.org/c/qt/qtbase/+/764810), so the Qt 5.15 and 6.11.1 builds need desktop-app/patches#265 to compile.

Used by telegramdesktop/tdesktop#31218 for the message lists. Verified with NVDA on Windows 10: the chat list, the folder tabs, the countries and languages lists and the message lists all announce "n of N" after the row name.
