### PR TITLE
Fix the keyboard handling of a radio group

### DIFF
--- a/ui/widgets/checkbox.cpp
+++ b/ui/widgets/checkbox.cpp
@@ -1036,14 +1036,14 @@ void Radiobutton::trackScreenReaderState() {
 		if (!screenReaderActive || !value.has_value()) {
 			return Qt::NoFocus;
 		} else if (value == _value) {
-			return Qt::StrongFocus;
+			return Qt::TabFocus;
 		}
 		for (const auto &button : _group->_buttons) {
 			if (button->_value == value) {
 				return Qt::NoFocus;
 			}
 		}
-		return Qt::StrongFocus;
+		return Qt::TabFocus;
 	}) | rpl::on_next([=](Qt::FocusPolicy value) {
 		if (focusPolicy() != value) {
 			setFocusPolicy(value);

--- a/ui/widgets/checkbox.cpp
+++ b/ui/widgets/checkbox.cpp
@@ -1092,8 +1092,14 @@ void Radiobutton::keyPressEvent(QKeyEvent *e) {
 		? buttons[currentIndex - 1]
 		: buttons[currentIndex + 1];
 
-	const auto deltaY = std::abs(neighbor->y() - y());
-	const auto deltaX = std::abs(neighbor->x() - x());
+	// In global coordinates: the buttons of one group are not always
+	// siblings - each one may sit in a wrap of its own, like the correct
+	// answer buttons of a quiz - and their positions inside those parents
+	// say nothing about how the group is laid out on the screen.
+	const auto position = mapToGlobal(QPoint());
+	const auto neighborPosition = neighbor->mapToGlobal(QPoint());
+	const auto deltaY = std::abs(neighborPosition.y() - position.y());
+	const auto deltaX = std::abs(neighborPosition.x() - position.x());
 	const auto orientation = (deltaY > deltaX)
 		? Qt::Vertical
 		: Qt::Horizontal;

--- a/ui/widgets/checkbox.cpp
+++ b/ui/widgets/checkbox.cpp
@@ -1111,15 +1111,22 @@ void Radiobutton::keyPressEvent(QKeyEvent *e) {
 	}
 
 	const auto step = (key == Qt::Key_Down || key == Qt::Key_Right) ? 1 : -1;
-	const auto nextIndex = currentIndex + step;
 
-	if (nextIndex >= 0 && nextIndex < buttons.size()) {
+	// Pass over the buttons that are hidden or disabled - the correct
+	// answer button of an empty quiz row is kept hidden until the row is
+	// filled in - or an arrow would check something that is not there.
+	auto nextIndex = currentIndex + step;
+	while (nextIndex >= 0 && nextIndex < buttons.size()) {
 		const auto nextButton = buttons[nextIndex];
-		const auto weak = base::make_weak(nextButton);
-		_group->setValue(nextButton->_value);
-		if (const auto strong = weak.get()) {
-			strong->setFocus(Qt::OtherFocusReason);
+		if (nextButton->isVisible() && nextButton->isEnabled()) {
+			const auto weak = base::make_weak(nextButton);
+			_group->setValue(nextButton->_value);
+			if (const auto strong = weak.get()) {
+				strong->setFocus(Qt::OtherFocusReason);
+			}
+			return;
 		}
+		nextIndex += step;
 	}
 }
 


### PR DESCRIPTION
Two fixes for the keyboard handling of a radio group, both in Radiobutton.

The roving Tab stop of the group was given Qt::StrongFocus, which also takes keyboard focus on a mouse click - a change for everyone, while all the group needs is to be reachable with Tab. Qt::TabFocus is what the rest of the accessibility code resolves its focusable widgets to, and it leaves the mouse behaviour alone.

The arrows move between the buttons along the axis the group is laid out on, found by comparing the position of a button with the one next to it. Those positions were read inside their parents, which works only while the buttons are siblings. The correct answer buttons of a quiz (Ui::FadeWrapScaled in create_poll_box), the rows of Settings > Privacy > Auto-delete messages and the premium gift options each put their button in a wrap of its own, at the same position inside it, so the group looked horizontal: Up / Down did nothing on a list of answers going down the box, while Left / Right moved through it. Comparing global positions fixes those and changes nothing where the buttons are siblings.

Verified with NVDA on Windows 10: in the quiz answers of a new poll the arrows now follow the list downwards and Left / Right are ignored, and the radio list of the self-destruct box, whose buttons are siblings, is unchanged.
