### PR TITLE
Tell a field's Tab handler when the default order is wanted

### DIFF
--- a/ui/widgets/fields/input_field.cpp
+++ b/ui/widgets/fields/input_field.cpp
@@ -25,6 +25,7 @@
 #include "ui/painter.h"
 #include "ui/qt_object_factory.h"
 #include "ui/integration.h"
+#include "ui/screen_reader_mode.h"
 #include "styles/style_widgets.h"
 #include "styles/palette.h"
 
@@ -4378,7 +4379,10 @@ void InputField::keyPressEventInner(QKeyEvent *e) {
 			e->ignore();
 		} else {
 			const auto forward = (key == Qt::Key_Tab) && !shift;
-			auto request = TabbedRequest{ .backward = !forward };
+			auto request = TabbedRequest{
+				.backward = !forward,
+				.defaultOrder = ScreenReaderModeActive(),
+			};
 			_tabbed.fire(&request);
 			if (!request.handled && !focusNextPrevChild(forward)) {
 				e->ignore();

--- a/ui/widgets/fields/input_field.h
+++ b/ui/widgets/fields/input_field.h
@@ -152,6 +152,14 @@ public:
 	struct TabbedRequest {
 		bool backward = false;
 		bool handled = false;
+
+		// Set when Tab should follow the default focus order instead: in
+		// screen reader mode the buttons and settings around the fields
+		// are Tab stops, and a handler that would only pass the focus on
+		// to another field is expected to leave the request alone. One
+		// that uses Tab for something else - accepting a suggestion -
+		// goes ahead as usual.
+		bool defaultOrder = false;
 	};
 	static const QString kTagBold;
 	static const QString kTagItalic;


### PR DESCRIPTION
Several boxes wire Tab between their fields by hand (poll: question → answers → back; checklist, "Edit your name", "Add link" likewise). The buttons around the fields are not focusable, so nothing was lost — until screen reader mode, where those buttons and settings are Tab stops and the ring closed on the fields keeps the keyboard from ever reaching them.

`InputField::TabbedRequest` gets a `defaultOrder` flag, set by the field itself in screen reader mode. A handler that would only pass the focus on to another field leaves such a request alone and the field falls back to the default traversal; a handler that uses Tab for something else (accepting an autocomplete suggestion) goes ahead as before.

The tdesktop side (poll, checklist, name and link boxes) builds on this.