### PR TITLE
Name a checkbox without a label by its accessible name

### DIFF
--- a/ui/widgets/checkbox.h
+++ b/ui/widgets/checkbox.h
@@ -209,7 +209,11 @@ public:
 		return QAccessible::Role::CheckBox;
 	}
 	QString accessibilityName() override {
-		return _text.toString();
+		// A checkbox with no label of its own - beside a poll answer, in a
+		// list row - is named by what stands for it, through the widget's
+		// accessible name.
+		const auto text = _text.toString();
+		return text.isEmpty() ? RpWidget::accessibilityName() : text;
 	}
 	AccessibilityState accessibilityState() const override;
 	void accessibilityDoAction(const QString &name) override;


### PR DESCRIPTION
`Checkbox::accessibilityName()` returns the label text, so a checkbox or radio button created without one — the correct answer button beside a poll answer, where the answer stands for the label — had no name for a screen reader and no way to be given one. Fall back to the widget's accessible name when the label is empty. Labelled checkboxes are unchanged.