### PR TITLE
Open a dropdown menu for a screen reader like a popup one

### DIFF
--- a/ui/widgets/dropdown_menu.cpp
+++ b/ui/widgets/dropdown_menu.cpp
@@ -6,6 +6,8 @@
 //
 #include "ui/widgets/dropdown_menu.h"
 
+#include "ui/screen_reader_mode.h"
+
 #include <QtGui/QtEvents>
 
 namespace Ui {
@@ -31,6 +33,7 @@ DropdownMenu::DropdownMenu(QWidget *parent, const style::DropdownMenu &st) : Inn
 //}
 
 void DropdownMenu::init() {
+	InnerDropdown::setShownCallback([this] { showFinish(); });
 	InnerDropdown::setHiddenCallback([this] { hideFinish(); });
 
 	_menu->resizesFromInner(
@@ -228,6 +231,18 @@ void DropdownMenu::hideMenu(bool fast) {
 void DropdownMenu::childHiding(DropdownMenu *child) {
 	if (_activeSubmenu && _activeSubmenu == child) {
 		_activeSubmenu = SubmenuPointer();
+	}
+}
+
+void DropdownMenu::showFinish() {
+	// A popup menu opens for a screen reader as if from the keyboard: the
+	// first item is selected, takes the focus and is announced, and the
+	// arrows go on from there. A dropdown just appeared in the window,
+	// with nothing selected and nothing to hear. Do the same here, once
+	// the content is visible - a selected item that is still hidden
+	// behind the show animation could not hold the focus.
+	if (ScreenReaderModeActive()) {
+		_menu->setShowSource(TriggeredSource::Keyboard);
 	}
 }
 

--- a/ui/widgets/dropdown_menu.h
+++ b/ui/widgets/dropdown_menu.h
@@ -65,6 +65,7 @@ private:
 	void childHiding(DropdownMenu *child);
 
 	void init();
+	void showFinish();
 	void hideFinish();
 
 	using TriggeredSource = Menu::TriggeredSource;

--- a/ui/widgets/inner_dropdown.cpp
+++ b/ui/widgets/inner_dropdown.cpp
@@ -121,7 +121,7 @@ void InnerDropdown::paintEvent(QPaintEvent *e) {
 	} else if (_showAnimation) {
 		_showAnimation->paintFrame(p, 0, 0, width(), 1., 1.);
 		_showAnimation.reset();
-		showChildren();
+		showFinished();
 	} else {
 		if (!_cache.isNull()) _cache = QPixmap();
 		const auto inner = rect().marginsRemoved(_st.padding);
@@ -219,12 +219,16 @@ void InnerDropdown::finishAnimating() {
 
 void InnerDropdown::showFast() {
 	_hideTimer.cancel();
+	const auto showing = isHidden() || _hiding || (_showAnimation != nullptr);
 	finishAnimating();
 	if (isHidden()) {
 		showChildren();
 		saveFocusWidgetAndShow();
 	}
 	_hiding = false;
+	if (showing) {
+		showFinished();
+	}
 }
 
 void InnerDropdown::hideFast() {
@@ -367,8 +371,15 @@ void InnerDropdown::opacityAnimationCallback() {
 			_hiding = false;
 			hideFinished();
 		} else if (!_a_show.animating()) {
-			showChildren();
+			showFinished();
 		}
+	}
+}
+
+void InnerDropdown::showFinished() {
+	showChildren();
+	if (const auto onstack = _shownCallback) {
+		onstack();
 	}
 }
 

--- a/ui/widgets/inner_dropdown.h
+++ b/ui/widgets/inner_dropdown.h
@@ -62,6 +62,10 @@ public:
 	void setHiddenCallback(Fn<void()> callback) {
 		_hiddenCallback = std::move(callback);
 	}
+	// Fired once the dropdown is fully shown, with its content visible.
+	void setShownCallback(Fn<void()> callback) {
+		_shownCallback = std::move(callback);
+	}
 
 	bool isHiding() const {
 		return _hiding && _a_opacity.animating();
@@ -103,6 +107,7 @@ private:
 	void maybeReturnFocus();
 	void hideFinished();
 	void showStarted();
+	void showFinished();
 
 	void scrolled();
 
@@ -123,6 +128,7 @@ private:
 	Fn<void()> _showStartCallback;
 	Fn<void()> _hideStartCallback;
 	Fn<void()> _hiddenCallback;
+	Fn<void()> _shownCallback;
 
 	object_ptr<ScrollArea> _scroll;
 

--- a/ui/widgets/menu/menu_item_base.cpp
+++ b/ui/widgets/menu/menu_item_base.cpp
@@ -6,8 +6,10 @@
 //
 #include "ui/widgets/menu/menu_item_base.h"
 
+#include "ui/screen_reader_mode.h"
 #include "ui/widgets/menu/menu.h"
 
+#include <QtGui/QAccessible>
 #include <QtGui/QtEvents>
 
 namespace Ui::Menu {
@@ -30,6 +32,14 @@ void ItemBase::setSelected(
 		_lastTriggeredSource = source;
 		_selected = selected;
 		update();
+		if (selected
+			&& focusPolicy() == Qt::NoFocus
+			&& ScreenReaderModeActive()) {
+			// The focus policy is granted when the screen reader first
+			// queries the item. A popup menu is queried as its window
+			// appears, a menu inside the window may not have been yet.
+			QAccessible::queryAccessibleInterface(this);
+		}
 		if (selected && focusPolicy() != Qt::NoFocus) {
 			setFocus();
 			QAccessibleEvent event(this, QAccessible::Focus);


### PR DESCRIPTION
A `PopupMenu` shown in screen reader mode opens as if from the keyboard: the first item is selected, takes the focus and is announced, arrows go on from there. A `DropdownMenu` (the attach menu of the composer, "send as") just appeared inside the window with nothing selected, so a screen reader had nothing to say and Space on the paperclip seemed to do nothing.

- `InnerDropdown` gets a shown callback, fired once the content is visible (after the show animation, or at once for `showFast`), mirroring the hidden callback.
- `DropdownMenu` uses it to select the first item in screen reader mode, like `PopupMenu` does.
- A selected menu item forces its lazy accessibility registration, so it can take the focus even when the screen reader has not queried it yet (a popup's new window gets queried, a menu inside the window may not).

Focus returns to the toggle on hide through the existing save/return logic. Mouse behaviour is unchanged.