### PR TITLE
Dispatch the showMenu action of an expandable painted item

### DIFF
--- a/ui/accessible/ui_accessible_item.cpp
+++ b/ui/accessible/ui_accessible_item.cpp
@@ -233,6 +233,11 @@ QStringList Item::actionNames() const {
 	if (childState.selectable) {
 		names.append(QAccessibleActionInterface::toggleAction());
 	}
+	// An expandable item opens something of its own: the Windows bridge
+	// expands and collapses it through the showMenu action.
+	if (childState.expandable) {
+		names.append(QAccessibleActionInterface::showMenuAction());
+	}
 	return names;
 }
 
@@ -253,6 +258,8 @@ void Item::doAction(const QString &actionName) {
 		parent->accessibilityChildSetFocus(identity);
 	} else if (actionName == QAccessibleActionInterface::pressAction()) {
 		parent->accessibilityChildActivate(identity);
+	} else if (actionName == QAccessibleActionInterface::showMenuAction()) {
+		parent->accessibilityChildShowMenu(identity);
 	}
 }
 

--- a/ui/rp_widget.cpp
+++ b/ui/rp_widget.cpp
@@ -490,6 +490,9 @@ void RpWidget::accessibilityChildSetFocus(quintptr identity) {
 void RpWidget::accessibilityChildActivate(quintptr identity) {
 }
 
+void RpWidget::accessibilityChildShowMenu(quintptr identity) {
+}
+
 QString RpWidget::accessibilityName() {
 	return QWidget::accessibleName();
 }

--- a/ui/rp_widget.h
+++ b/ui/rp_widget.h
@@ -490,6 +490,12 @@ public:
 	virtual void accessibilityChildSetFocus(quintptr identity);
 	virtual void accessibilityChildActivate(quintptr identity);
 
+	// The showMenu action of a child that reports itself expandable: the
+	// assistive technology expands it with it when collapsed, and
+	// collapses it when expanded - a picker of variants opened over an
+	// item, say. Advertised only with the expandable state.
+	virtual void accessibilityChildShowMenu(quintptr identity);
+
 	// Keep this widget's Tab-focusable children ordered in the focus chain
 	// by visual position (row bands top-to-bottom, left-to-right within a
 	// band, mirrored in RTL) instead of widget creation order. The chain is


### PR DESCRIPTION
An item of a painted list that opens something of its own — the picker of an emoji's skin tones — reports itself `expandable`, and the Windows UIA bridge expands and collapses such an element through the `showMenu` action (desktop-app/patches#266 makes the bridge offer the ExpandCollapse pattern for it).

`Ui::Accessible::Item` advertises `showMenuAction()` when the child state is expandable and dispatches it by identity to a new `RpWidget::accessibilityChildShowMenu()` (default no-op), like SetFocus and Invoke. Note: a new virtual on `RpWidget` — a full rebuild of dependents is needed.

Used by telegramdesktop/tdesktop emoji panel variants PR.